### PR TITLE
Replace PrivateHostedZone ID attribute with reference

### DIFF
--- a/templates/aws-tap-entrypoint-existing-vpc.template.yaml
+++ b/templates/aws-tap-entrypoint-existing-vpc.template.yaml
@@ -1026,7 +1026,7 @@ Resources:
                 Action:
                   - route53:ListResourceRecordSets
                   - route53:ChangeResourceRecordSets
-                Resource: !Sub arn:${AWS::Partition}:route53:::hostedzone/${PrivateHostedZone.Id}
+                Resource: !Sub arn:${AWS::Partition}:route53:::hostedzone/${PrivateHostedZone}
               - Sid: ManageCloudWatchLogs
                 Effect: Allow
                 Action:
@@ -1440,7 +1440,7 @@ Resources:
               buildservice_arn: ${TAPBuildServiceIamRole.Arn}
             dns:
               domain_name: ${TAPDomainName}
-              zone_id: ${PrivateHostedZone.Id}
+              zone_id: ${PrivateHostedZone}
             repositories:
               tap_packages: ${TAPPackagesRepo.RepositoryUri}
               cluster_essentials: ${TAPClusterEssentialsBundleRepo.RepositoryUri}


### PR DESCRIPTION
Discovered an undocumented feature gap, which is that GovCloud doesn't support the ID attribute for the `AWS::Route53::HostedZone` resource ([reference](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-route53-hostedzone.html#aws-resource-route53-hostedzone-return-values)), but the reference works.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
