### PR TITLE
Added AllowedPattern for RemoteAccessCidr parameter

### DIFF
--- a/templates/aws-tap-entrypoint-existing-vpc.template.yaml
+++ b/templates/aws-tap-entrypoint-existing-vpc.template.yaml
@@ -441,6 +441,8 @@ Parameters:
     Description: >-
       IPv4 CIDR block permitted to connect to the Windows and Linux bastion
       hosts. We recommend that you set this value to a trusted network.
+    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(3[0-2]|[1-2][0-9]|[0-9]))$
+    ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/0-32
   LinuxBastionOS:
     Type: String
     Description: >-

--- a/templates/aws-tap-entrypoint-new-vpc.template.yaml
+++ b/templates/aws-tap-entrypoint-new-vpc.template.yaml
@@ -491,6 +491,8 @@ Parameters:
     Description: >-
       IPv4 CIDR block permitted to connect to the Windows and Linux bastion
       hosts. We recommend that you set this value to a trusted network.
+    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(3[0-2]|[1-2][0-9]|[0-9]))$
+    ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/0-32
   LinuxBastionOS:
     Type: String
     Description: >-


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Added an AllowedPattern to check the RemoteAccessCidr parameter. It's a required parameter otherwise it will cause an error in CloudFormation

Embedded stack arn:aws:cloudformation:us-east-1:816333157034:stack/vmware-tanzu-application-platform-1-2-ExistingVpcStack-7UAE0RNJB7RV/be9c4d20-0c1e-11ed-b0ef-0ebb957d5521 was not successfully created: The following resource(s) failed to create: [LinuxBastionSshIngressRule, WindowsBastionRdpIngressRule, EKSQSStack].

As remote CIDR is unique to each customer, we cannot provide a secure default without opening remote access to the world.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
