### PR TITLE
TAP 1.3.0 release updates

### DIFF
--- a/tap-setup-scripts/src/inputs/tap-values.yaml
+++ b/tap-setup-scripts/src/inputs/tap-values.yaml
@@ -5,16 +5,28 @@ ceip_policy_disclosed: true # Installation fails if this is set to 'false'
 buildservice:
   kp_default_repository: #@ data.values.repositories.build_service
   kp_default_repository_aws_iam_role_arn: #@ data.values.buildservice.buildservice_arn
-  tanzunet_username: #@ data.values.tanzunet.username
-  tanzunet_password: #@ data.values.tanzunet.password
   enable_automatic_dependency_updates: false
 
-supply_chain: testing
+supply_chain: testing_scanning
 
 ootb_templates:
   iaas_auth: true
 
+ootb_supply_chain_basic:
+  registry:
+    server: #@ data.values.repositories.workload.server
+    repository: #@ data.values.repositories.workload.ootb_repo_prefix
+  gitops:
+    ssh_secret: ""
+
 ootb_supply_chain_testing:
+  registry:
+    server: #@ data.values.repositories.workload.server
+    repository: #@ data.values.repositories.workload.ootb_repo_prefix
+  gitops:
+    ssh_secret: ""
+
+ootb_supply_chain_testing_scanning:
   registry:
     server: #@ data.values.repositories.workload.server
     repository: #@ data.values.repositories.workload.ootb_repo_prefix
@@ -32,6 +44,14 @@ tap_gui:
   ingressDomain: #@ data.values.dns.domain_name
   service_type: ClusterIP # NodePort for distributions that don't support LoadBalancer
   app_config:
+    proxy:
+      /metadata-store:
+        target: https://metadata-store-app.metadata-store:8443/api/v1
+        changeOrigin: true
+        secure: false
+        headers:
+          Authorization: #@ "{}".format(data.values.metadata_store.access_token)
+          X-Custom-Source: project-star
     supplyChain:
       enablePlugin: true
     auth:
@@ -44,9 +64,7 @@ tap_gui:
       baseUrl: #@ "http://tap-gui.{}".format(data.values.dns.domain_name)
 
 metadata_store:
-  ingressEnabled: true
-  ingressDomain: #@ data.values.dns.domain_name
-  app_service_type: ClusterIP
+  ns_for_export_app_cert: #@ data.values.repositories.workload.namespace
 
 contour:
   infrastructure_provider: aws
@@ -60,3 +78,7 @@ cnrs:
 
 grype:
   namespace: #@ data.values.repositories.workload.namespace
+
+scanning:
+  metadataStore:
+    url: "" # Disable embedded integration since it's deprecated

--- a/tap-setup-scripts/src/inputs/user-input-values.example.yaml
+++ b/tap-setup-scripts/src/inputs/user-input-values.example.yaml
@@ -4,7 +4,7 @@ tanzunet:
   server: registry.tanzu.vmware.com
   relocate_images: "Yes"
   secrets:
-    credentials_arn:
+    credentials_arn: arn:aws:secretsmanager:us-east-1:012345678901:secret:a10ba9b0-232d-11ed-b3d9-0ebc7567a9a9/TanzuNetCredentials-qAzM3L
 cluster_essentials_bundle:
   bundle: registry.tanzu.vmware.com/tanzu-cluster-essentials/cluster-essentials-bundle
   file_hash: sha256:e00f33b92d418f49b1af79f42cb13d6765f1c8c731f4528dfff8343af042dc3e
@@ -13,7 +13,7 @@ tap:
   name: tap
   namespace: tap-install
   repository: registry.tanzu.vmware.com/tanzu-application-platform/tap-packages
-  version: 1.2.0
+  version: 1.3.0-rc.1
 cluster:
   name: example-tap-eks-cluster
 dns:
@@ -28,3 +28,4 @@ repositories:
     namespace: tap-workload
     repository: 012345678901.dkr.ecr.us-east-1.amazonaws.com/621187b4-c917-46c0-9341-f5067b3afd97/tap-supply-chain/tanzu-java-web-app-workload-tap-workload
     bundle_repository: 012345678901.dkr.ecr.us-east-1.amazonaws.com/621187b4-c917-46c0-9341-f5067b3afd97/tap-supply-chain/tanzu-java-web-app-workload-tap-workload-bundle
+    arn: arn:aws:iam::012345678901:role/TAPWorkloadIamRole-a10ba9b0-232d-11ed-b3d9-0ebc7567a9a9

--- a/tap-setup-scripts/src/resources/developer-namespace.yaml
+++ b/tap-setup-scripts/src/resources/developer-namespace.yaml
@@ -64,7 +64,9 @@ rules:
 - apiGroups: [scanning.apps.tanzu.vmware.com]
   resources: ['imagescans', 'sourcescans']
   verbs: ['*']
-
+- apiGroups: [conventions.carto.run]
+  resources: [podintents]
+  verbs: ['*']
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/tap-setup-scripts/src/resources/metadata-store-ready-only.yaml
+++ b/tap-setup-scripts/src/resources/metadata-store-ready-only.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: metadata-store
+  labels:
+    name: metadata-store
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: metadata-store-ready-only
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: metadata-store-read-only
+subjects:
+- kind: ServiceAccount
+  name: metadata-store-read-client
+  namespace: metadata-store
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: metadata-store-read-client
+  namespace: metadata-store
+automountServiceAccountToken: false

--- a/tap-setup-scripts/src/resources/scan-policy.yaml
+++ b/tap-setup-scripts/src/resources/scan-policy.yaml
@@ -1,13 +1,16 @@
+---
 apiVersion: scanning.apps.tanzu.vmware.com/v1beta1
 kind: ScanPolicy
 metadata:
   name: scan-policy
+  labels:
+    'app.kubernetes.io/part-of': 'enable-in-gui'
 spec:
   regoFile: |
     package main
 
     # Accepted Values: "Critical", "High", "Medium", "Low", "Negligible", "UnknownSeverity"
-    notAllowedSeverities := ["Critical","High","UnknownSeverity"]
+    notAllowedSeverities := []
     ignoreCves := []
 
     contains(array, elem) = true {
@@ -15,19 +18,25 @@ spec:
     } else = false { true }
 
     isSafe(match) {
-      fails := contains(notAllowedSeverities, match.ratings.rating[_])
+      severities := { e | e := match.ratings.rating.severity } | { e | e := match.ratings.rating[_].severity }
+      some i
+      fails := contains(notAllowedSeverities, severities[i])
       not fails
     }
 
     isSafe(match) {
-      ignore := contains(ignoreCves, match.Id)
+      ignore := contains(ignoreCves, match.id)
       ignore
     }
 
     deny[msg] {
-      comp := input.bom.components.component[_]
-      vuln := comp.vulnerabilities.vulnerability[_]
-      ratings := vuln.ratings.rating[_]
+      comps := { e | e := input.bom.components.component } | { e | e := input.bom.components.component[_] }
+      some i
+      comp := comps[i]
+      vulns := { e | e := comp.vulnerabilities.vulnerability } | { e | e := comp.vulnerabilities.vulnerability[_] }
+      some j
+      vuln := vulns[j]
+      ratings := { e | e := vuln.ratings.rating.severity } | { e | e := vuln.ratings.rating[_].severity }
       not isSafe(vuln)
       msg = sprintf("CVE %s %s %s", [comp.name, vuln.id, ratings])
     }

--- a/templates/aws-tap-entrypoint-existing-vpc.template.yaml
+++ b/templates/aws-tap-entrypoint-existing-vpc.template.yaml
@@ -493,8 +493,8 @@ Parameters:
       refer to Kubernetes cluster requirements
       (https://docs.vmware.com/en/VMware-Tanzu-Application-Platform/1.2/tap/GUID-prerequisites.html#kubernetes-cluster-requirements-3).
     AllowedValues:
-      - 1.2.0
-    Default: 1.2.0
+      - 1.3.0-rc.1
+    Default: 1.3.0-rc.1
   SampleAppName:
     Type: String
     Description: >-
@@ -645,7 +645,7 @@ Mappings:
     '1.22':
       AwsKubectlVersion: 1.23.7/2022-06-29
   TAPVersion:
-    1.2.0:
+    1.3.0-rc.1:
       ClusterEssentialsBundleVersion: 1.2.0
   ClusterEssentialsBundle:
     1.1.0:
@@ -1676,7 +1676,7 @@ Rules:
           Customer Experience Improvement Program (CEIP) policy before you can
           proceed with the installation.
   TAP1.2Interop:
-    RuleCondition: !Contains [[1.2.0], !Ref TAPVersion]
+    RuleCondition: !Contains [[1.3.0-rc.1], !Ref TAPVersion]
     Assertions:
       # The values below require quotes to force string comparison.
       - Assert: !Contains [['1.22', '1.23', '1.24'], !Ref KubernetesVersion]

--- a/templates/aws-tap-entrypoint-existing-vpc.template.yaml
+++ b/templates/aws-tap-entrypoint-existing-vpc.template.yaml
@@ -75,9 +75,9 @@ Metadata:
           - QSS3KeyPrefix
     ParameterLabels:
       AcceptEULAs:
-        default: Have all applicable VMware Tanzu Network EULAs been accepted?
+        default: Have you read and accepted all applicable VMware Tanzu Network EULAs?
       AcceptCEIP:
-        default: Have you read and accept the VMware CEIP policy?
+        default: Have you already read and accepted the VMware CEIP policy?
       KeyPairName:
         default: EC2 key pair name
       VpcId:
@@ -204,13 +204,14 @@ Parameters:
     ConstraintDescription: >-
       Minimum length of 1. Maximum length of 100. Must start with a letter or
       number.
+    Default: cluster-eks-tap
   KubernetesVersion:
     Type: String
     Description: >-
       Version of Kubernetes control plane to deploy. The selected version must
       be supported the selected TAP version (TAPVersion). For more information,
       refer to Kubernetes cluster requirements
-      (https://docs.vmware.com/en/VMware-Tanzu-Application-Platform/1.2/tap/GUID-prerequisites.html#kubernetes-cluster-requirements-3).
+      (https://docs.vmware.com/en/VMware-Tanzu-Application-Platform/1.3/tap/GUID-prerequisites.html#kubernetes-cluster-requirements-3).
     AllowedValues:
       - 1.22
     Default: 1.22
@@ -491,10 +492,10 @@ Parameters:
       Version of TAP to deploy. The selected version must also support the
       selected Kubernetes version (KubernetesVersion). For more information,
       refer to Kubernetes cluster requirements
-      (https://docs.vmware.com/en/VMware-Tanzu-Application-Platform/1.2/tap/GUID-prerequisites.html#kubernetes-cluster-requirements-3).
+      (https://docs.vmware.com/en/VMware-Tanzu-Application-Platform/1.3/tap/GUID-prerequisites.html#kubernetes-cluster-requirements-3).
     AllowedValues:
-      - 1.3.0-rc.1
-    Default: 1.3.0-rc.1
+      - 1.3.0
+    Default: 1.3.0
   SampleAppName:
     Type: String
     Description: >-
@@ -645,13 +646,15 @@ Mappings:
     '1.22':
       AwsKubectlVersion: 1.23.7/2022-06-29
   TAPVersion:
-    1.3.0-rc.1:
-      ClusterEssentialsBundleVersion: 1.2.0
+    1.3.0:
+      ClusterEssentialsBundleVersion: 1.3.0
   ClusterEssentialsBundle:
     1.1.0:
       FileHash: sha256:ab0a3539da241a6ea59c75c0743e9058511d7c56312ea3906178ec0f3491f51d
     1.2.0:
       FileHash: sha256:e00f33b92d418f49b1af79f42cb13d6765f1c8c731f4528dfff8343af042dc3e
+    1.3.0:
+      FileHash: sha256:54bf611711923dccd7c7f10603c846782b90644d48f1cb570b43a082d18e23b9
   SampleAppProperties:
     Namespace:
       Name: tap-workload
@@ -1460,6 +1463,7 @@ Resources:
             aws s3 cp --no-progress "${QSS3BucketPath}/src/resources/git-ssh-basic-auth.yaml" ./git-ssh-basic-auth.yaml
             aws s3 cp --no-progress "${QSS3BucketPath}/src/resources/pipeline.yaml" ./pipeline.yaml
             aws s3 cp --no-progress "${QSS3BucketPath}/src/resources/scan-policy.yaml" ./scan-policy.yaml
+            aws s3 cp --no-progress "${QSS3BucketPath}/src/resources/metadata-store-ready-only.yaml" ./metadata-store-ready-only.yaml
             cat <<EOF > ./workload-aws.yaml
             ${SampleAppConfig}
             EOF
@@ -1675,12 +1679,12 @@ Rules:
           You must acknowledge that you have read and accept the VMware
           Customer Experience Improvement Program (CEIP) policy before you can
           proceed with the installation.
-  TAP1.2Interop:
-    RuleCondition: !Contains [[1.3.0-rc.1], !Ref TAPVersion]
+  TAPInterop:
+    RuleCondition: !Contains [[1.3.0], !Ref TAPVersion]
     Assertions:
       # The values below require quotes to force string comparison.
       - Assert: !Contains [['1.22', '1.23', '1.24'], !Ref KubernetesVersion]
         AssertDescription: >-
           The VMware Tanzu Application Platform version selection is
           incompatible with the Kubernetes version selection (reference:
-          https://docs.vmware.com/en/VMware-Tanzu-Application-Platform/1.1/tap/GUID-prerequisites.html#kubernetes-cluster-requirements-3).
+          https://docs.vmware.com/en/VMware-Tanzu-Application-Platform/1.3/tap/GUID-prerequisites.html#kubernetes-cluster-requirements-3).

--- a/templates/aws-tap-entrypoint-new-vpc.template.yaml
+++ b/templates/aws-tap-entrypoint-new-vpc.template.yaml
@@ -543,8 +543,8 @@ Parameters:
       refer to Kubernetes cluster requirements
       (https://docs.vmware.com/en/VMware-Tanzu-Application-Platform/1.2/tap/GUID-prerequisites.html#kubernetes-cluster-requirements-3).
     AllowedValues:
-      - 1.2.0
-    Default: 1.2.0
+      - 1.3.0-rc.1
+    Default: 1.3.0-rc.1
   SampleAppName:
     Type: String
     Description: >-
@@ -732,7 +732,7 @@ Rules:
           Customer Experience Improvement Program (CEIP) policy before you can
           proceed with the installation.
   TAP1.2Interop:
-    RuleCondition: !Contains [[1.2.0], !Ref TAPVersion]
+    RuleCondition: !Contains [[1.3.0-rc.1], !Ref TAPVersion]
     Assertions:
       # The values below require quotes to force string comparison.
       - Assert: !Contains [['1.22', '1.23', '1.24'], !Ref KubernetesVersion]

--- a/templates/aws-tap-entrypoint-new-vpc.template.yaml
+++ b/templates/aws-tap-entrypoint-new-vpc.template.yaml
@@ -79,9 +79,9 @@ Metadata:
           - QSS3KeyPrefix
     ParameterLabels:
       AcceptEULAs:
-        default: Have all applicable VMware Tanzu Network EULAs been accepted?
+        default: Have you read and accepted all applicable VMware Tanzu Network EULAs?
       AcceptCEIP:
-        default: Have you read and accept the VMware CEIP policy?
+        default: Have you already read and accepted the VMware CEIP policy?
       AvailabilityZones:
         default: Availability Zones
       NumberOfAZs:
@@ -254,13 +254,14 @@ Parameters:
     ConstraintDescription: >-
       Minimum length of 1. Maximum length of 100. Must start with a letter or
       number.
+    Default: cluster-eks-tap
   KubernetesVersion:
     Type: String
     Description: >-
       Version of Kubernetes control plane to deploy. The selected version must
       be supported the selected TAP version (TAPVersion). For more information,
       refer to Kubernetes cluster requirements
-      (https://docs.vmware.com/en/VMware-Tanzu-Application-Platform/1.2/tap/GUID-prerequisites.html#kubernetes-cluster-requirements-3).
+      (https://docs.vmware.com/en/VMware-Tanzu-Application-Platform/1.3/tap/GUID-prerequisites.html#kubernetes-cluster-requirements-3).
     AllowedValues:
       - 1.22
     Default: 1.22
@@ -541,10 +542,10 @@ Parameters:
       Version of TAP to deploy. The selected version must also support the
       selected Kubernetes version (KubernetesVersion). For more information,
       refer to Kubernetes cluster requirements
-      (https://docs.vmware.com/en/VMware-Tanzu-Application-Platform/1.2/tap/GUID-prerequisites.html#kubernetes-cluster-requirements-3).
+      (https://docs.vmware.com/en/VMware-Tanzu-Application-Platform/1.3/tap/GUID-prerequisites.html#kubernetes-cluster-requirements-3).
     AllowedValues:
-      - 1.3.0-rc.1
-    Default: 1.3.0-rc.1
+      - 1.3.0
+    Default: 1.3.0
   SampleAppName:
     Type: String
     Description: >-
@@ -728,15 +729,15 @@ Rules:
     Assertions:
       - Assert: !Equals [!Ref AcceptCEIP, 'Yes']
         AssertDescription: >-
-          You must acknowledge that you have read and accept the VMware
+          You must acknowledge that you have read and accepted the VMware
           Customer Experience Improvement Program (CEIP) policy before you can
           proceed with the installation.
-  TAP1.2Interop:
-    RuleCondition: !Contains [[1.3.0-rc.1], !Ref TAPVersion]
+  TAPInterop:
+    RuleCondition: !Contains [[1.3.0], !Ref TAPVersion]
     Assertions:
       # The values below require quotes to force string comparison.
       - Assert: !Contains [['1.22', '1.23', '1.24'], !Ref KubernetesVersion]
         AssertDescription: >-
           The VMware Tanzu Application Platform version selection is
           incompatible with the Kubernetes version selection (reference:
-          https://docs.vmware.com/en/VMware-Tanzu-Application-Platform/1.1/tap/GUID-prerequisites.html#kubernetes-cluster-requirements-3).
+          https://docs.vmware.com/en/VMware-Tanzu-Application-Platform/1.3/tap/GUID-prerequisites.html#kubernetes-cluster-requirements-3).


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Update TAP install scripts for TAP new release 1.3.0
- Update AcceptEULAs & AcceptCEIP ParameterLabels Descriptions.
- Add default value for EKS cluster name
- Update TAP 1.3 docs references
- Added TAP profile "testing_scanning"
-  Update Scan policy
- Integrate metadata store for TAP-GUI

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
