### PR TITLE
Remove explicit disabling of partner integrations, fix nesting, and bump the EKS submodule to latest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 taskcat_outputs/
 .taskcat/
 .taskcat_overrides.yml
+*.zip
 
 # Docs
 docs/

--- a/.taskcat.yml
+++ b/.taskcat.yml
@@ -3,6 +3,10 @@ project:
   owner: quickstart-eng@amazon.com
   s3_regional_buckets: true
   template: templates/aws-tap-entrypoint-new-vpc.template.yaml
+  package_lambda: true
+  lambda_source_path: functions/source
+  lambda_zip_path: functions/packages
+  build_submodules: true
   parameters:
     AcceptEULAs: --override--
     AcceptCEIP: --override--

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+PROFILE ?= default
+REGIONS ?=
+ACCOUNT_STACK ?= true
+CLEAN_ACCOUNT ?= true
+CLEAN_TYPES ?= true
+CLEAN_REGIONAL ?= true
+
+clean:
+	rm -rf taskcat_outputs
+	rm -rf .taskcat
+	rm -rf functions/packages
+	rm -rf *.zip
+
+clean-aws:
+	PROFILE=$(PROFILE) submodules/quickstart-amazon-eks/build/clean-aws.sh "$(REGIONS)"
+
+lint:
+	cfn-lint templates/*.yaml
+	cfn-lint templates/workload/*.yaml
+
+init-submodules:
+	scripts/init-submodules.sh

--- a/scripts/init-submodules.sh
+++ b/scripts/init-submodules.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -xe
+
+stash_child_directories() {
+  local parent_directory=$1
+
+  pushd $parent_directory
+
+  for child_directory in *
+  do
+    if [ -d "${child_directory}" ]
+    then
+      pushd "${child_directory}"
+
+      git stash --include-untracked
+
+      popd
+    fi
+  done
+
+  popd
+}
+
+stash_child_directories './submodules/quickstart-amazon-eks/submodules'
+stash_child_directories './submodules'
+
+git submodule update --init --recursive

--- a/templates/aws-tap-entrypoint-existing-vpc.template.yaml
+++ b/templates/aws-tap-entrypoint-existing-vpc.template.yaml
@@ -822,19 +822,8 @@ Resources:
         NodeGroupOS: Amazon Linux 2
         EKSClusterName: !Ref EKSClusterName
         ClusterAutoScaler: Enabled
-        ProvisionBastionHost: Disabled
-        SnykIntegration: Disabled
-        NewRelicIntegration: Disabled
-        CalicoIntegration: Disabled
-        RafaySysIntegration: Disabled
-        GrafanaIntegration: Disabled
-        PrometheusIntegration: Disabled
-        VaultIntegration: Disabled
-        ConsulIntegration: Disabled
-        RancherIntegration: Disabled
         MonitoringStack: None
         ALBIngressController: Enabled
-        EfsStorageClass: Disabled
   TAPLogGroup:
     Type: AWS::Logs::LogGroup
     UpdateReplacePolicy: Retain

--- a/templates/aws-tap-entrypoint-existing-vpc.template.yaml
+++ b/templates/aws-tap-entrypoint-existing-vpc.template.yaml
@@ -802,6 +802,9 @@ Resources:
         - S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
           S3Region: !If [UsingDefaultBucket, !Ref AWS::Region, !Ref QSS3BucketRegion]
       Parameters:
+        QSS3BucketName: !Ref QSS3BucketName
+        QSS3BucketRegion: !Ref QSS3BucketRegion
+        QSS3KeyPrefix: !Sub ${QSS3KeyPrefix}submodules/quickstart-amazon-eks/
         ConfigSetName: !Ref AWS::StackName
         VPCID: !Ref VpcId
         PrivateSubnet1ID: !Ref PrivateSubnet1Id


### PR DESCRIPTION
The explicit disabling of EKS partner integrations that no longer exist is causing the EKS stack to fail to deploy. Removing as this is unnecessary as they will never be enabled by default. Additionally, we know that in the future more of these may be removed.

*Issue #, if available:*
#122
*Description of changes:*
remove explicit disabling of EKS partner integraions

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
