### PR TITLE
Exclude policy controller from TAP installation

### DIFF
--- a/tap-setup-scripts/src/inputs/tap-values.yaml
+++ b/tap-setup-scripts/src/inputs/tap-values.yaml
@@ -82,3 +82,6 @@ grype:
 scanning:
   metadataStore:
     url: "" # Disable embedded integration since it's deprecated
+
+excluded_packages:
+  - policy.apps.tanzu.vmware.com


### PR DESCRIPTION
The TUF key for policy controller 1.1.2 is invalid. This is causing TAP installation to fail. Per TAP guidance, exclude policy controller from installation

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
