### PR TITLE
[qs] release 1.4.2+aws.1

### DIFF
--- a/.taskcat.yml
+++ b/.taskcat.yml
@@ -18,7 +18,6 @@ project:
     TanzuNetUsername: --override--
     TanzuNetPassword: --override--
     TanzuNetApiToken: --override--
-    TanzuNetRelocateImages: --override--
     TAPDomainName: --override--
     QSS3BucketName: $[taskcat_autobucket]
     QSS3BucketRegion: $[taskcat_current_region]
@@ -30,11 +29,25 @@ tests:
   single-cluster:
     parameters:
       TAPClusterArch: single
+      TanzuNetRelocateImages: "No"
     regions:
       - us-east-1
       - eu-south-1
   multi-cluster:
     parameters:
       TAPClusterArch: multi
+      TanzuNetRelocateImages: "No"
     regions:
       - us-west-2
+  relocation-single:
+    parameters:
+      TAPClusterArch: single
+      TanzuNetRelocateImages: "Yes"
+    regions:
+      - us-west-2
+  relocation-multi:
+    parameters:
+      TAPClusterArch: multi
+      TanzuNetRelocateImages: "Yes"
+    regions:
+      - us-east-1

--- a/ci/qs-test/pipeline.yml
+++ b/ci/qs-test/pipeline.yml
@@ -108,13 +108,27 @@ alerting:
 
 groups:
 - name: main
-  jobs: [ prepare-bucket, test-static, test-single-us-east-1, test-single-eu-south-1, test-multi-us-west-2, publish-bucket, set-pipeline ]
+  jobs:
+  - prepare-bucket
+  - test-static
+  - test-single-us-east-1
+  - test-single-eu-south-1
+  - test-multi-us-west-2
+  - test-relocation-single-us-west-2
+  - test-relocation-multi-us-east-1
+  - publish-bucket
+  - set-pipeline
 - name: pr
-  jobs: [ "pr-*", set-pipeline ]
+  jobs:
+  - "pr-*"
+  - set-pipeline
 - name: housekeeping
-  jobs: [ "housekeeping-*", set-pipeline ]
+  jobs:
+  - "housekeeping-*"
+  - set-pipeline
 - name: all
-  jobs: [ "*" ]
+  jobs:
+  - "*"
 
 jobs:
 - name: set-pipeline
@@ -277,6 +291,58 @@ jobs:
       REGIONS: "us-west-2"
     ensure: *postTest
 
+- name: test-relocation-single-us-west-2
+  << : *alertingOnJobs
+  serial: true
+  plan:
+  - in_parallel:
+    - get: ci-repo
+      params:
+        submodules: none
+      trigger: true
+      passed: [ prepare-bucket ]
+    - get: repo
+      params:
+        submodules: none
+      trigger: true
+      passed: [ prepare-bucket ]
+    - get: daily-run
+      trigger: true
+      passed: [ prepare-bucket ]
+  - *setup
+  - task: taskcat-test
+    file: ci-repo/ci/tasks/taskcat-run-test/task.yml
+    params:
+      TEST_NAME: relocation-single
+      REGIONS: "us-west-2"
+    ensure: *postTest
+
+- name: test-relocation-multi-us-east-1
+  << : *alertingOnJobs
+  serial: true
+  plan:
+  - in_parallel:
+    - get: ci-repo
+      params:
+        submodules: none
+      trigger: true
+      passed: [ prepare-bucket ]
+    - get: repo
+      params:
+        submodules: none
+      trigger: true
+      passed: [ prepare-bucket ]
+    - get: daily-run
+      trigger: true
+      passed: [ prepare-bucket ]
+  - *setup
+  - task: taskcat-test
+    file: ci-repo/ci/tasks/taskcat-run-test/task.yml
+    params:
+      TEST_NAME: relocation-multi
+      REGIONS: "us-east-1"
+    ensure: *postTest
+
 - name: publish-bucket
   << : *alertingOnJobs
   plan:
@@ -285,12 +351,17 @@ jobs:
       params:
         submodules: none
       trigger: true
-      passed: [ test-single-us-east-1, test-single-eu-south-1, test-multi-us-west-2 ]
+      passed: &passedForPublishBucket
+      - test-single-us-east-1
+      - test-single-eu-south-1
+      - test-multi-us-west-2
+      - test-relocation-single-us-west-2
+      - test-relocation-multi-us-east-1
     - get: repo
       params:
         submodules: none
       trigger: true
-      passed: [ test-single-us-east-1, test-single-eu-south-1, test-multi-us-west-2 ]
+      passed: *passedForPublishBucket
   - *setup
   - task: publish-bucket
     file: ci-repo/ci/tasks/taskcat-bucket-sync/task.yml
@@ -420,12 +491,61 @@ jobs:
       REGIONS: "us-west-2"
     ensure: *postTest
 
+- name: pr-test-relocation-single-us-west-2
+  << : *alertginOnPrJobs
+  serial: true
+  plan:
+  - in_parallel:
+    - get: ci-repo
+      params:
+        submodules: none
+      trigger: true
+      passed: [ pr-prepare-bucket ]
+    - get: repo
+      resource: pull-request
+      trigger: true
+      passed: [ pr-prepare-bucket ]
+  - *setup
+  - task: taskcat-test
+    file: ci-repo/ci/tasks/taskcat-run-test/task.yml
+    params:
+      TEST_NAME: relocation-single
+      REGIONS: "us-west-2"
+    ensure: *postTest
+
+- name: pr-test-relocation-multi-us-east-1
+  << : *alertginOnPrJobs
+  serial: true
+  plan:
+  - in_parallel:
+    - get: ci-repo
+      params:
+        submodules: none
+      trigger: true
+      passed: [ pr-prepare-bucket ]
+    - get: repo
+      resource: pull-request
+      trigger: true
+      passed: [ pr-prepare-bucket ]
+  - *setup
+  - task: taskcat-test
+    file: ci-repo/ci/tasks/taskcat-run-test/task.yml
+    params:
+      TEST_NAME: relocation-multi
+      REGIONS: "us-east-1"
+    ensure: *postTest
+
 - name: pr-set-success
   plan:
   - get: repo
     resource: pull-request
     trigger: true
-    passed: [ pr-test-single-us-east-1, pr-test-single-eu-south-1, pr-test-multi-us-west-2 ]
+    passed:
+    - pr-test-single-us-east-1
+    - pr-test-single-eu-south-1
+    - pr-test-multi-us-west-2
+    - pr-test-relocation-single-us-west-2
+    - pr-test-relocation-multi-us-east-1
   - put: pull-request
     params:
       path: repo

--- a/ci/qs-test/pipeline.yml
+++ b/ci/qs-test/pipeline.yml
@@ -29,7 +29,6 @@ resources:
     - ci/qs-test/
     - ci/tasks/
 - name: housekeeping-daily
-  old_name: houekeeping-time
   icon: wrench-clock
   type: time
   source:
@@ -207,7 +206,6 @@ jobs:
 - name: test-single-us-east-1
   << : *alertingOnJobs
   serial: true
-  old_name: test-single
   plan:
   - in_parallel:
     - get: ci-repo
@@ -267,7 +265,6 @@ jobs:
 - name: test-multi-us-west-2
   << : *alertingOnJobs
   serial: true
-  old_name: test-multi
   plan:
   - in_parallel:
     - get: ci-repo
@@ -426,7 +423,6 @@ jobs:
 - name: pr-test-single-us-east-1
   << : *alertginOnPrJobs
   serial: true
-  old_name: pr-test-single
   plan:
   - in_parallel:
     - get: ci-repo
@@ -471,7 +467,6 @@ jobs:
 - name: pr-test-multi-us-west-2
   << : *alertginOnPrJobs
   serial: true
-  old_name: pr-test-multi
   plan:
   - in_parallel:
     - get: ci-repo

--- a/ci/qs-test/taskcat_overlay.yml
+++ b/ci/qs-test/taskcat_overlay.yml
@@ -37,7 +37,6 @@ project:
     TanzuNetUsername: #@ tanzunet_username
     TanzuNetPassword: #@ tanzunet_password
     TanzuNetApiToken: #@ tanzunet_refreshToken
-    TanzuNetRelocateImages: "No"
     TAPDomainName: #@ "{}.{}".format("$[taskcat_random-string]", domain)
     QSS3KeyPrefix: #@ gitSha + "/"
   tags:

--- a/tap-setup-scripts/src/cloud-init.sh
+++ b/tap-setup-scripts/src/cloud-init.sh
@@ -1,12 +1,14 @@
 #!/usr/bin/env bash
 
-set -ex
+set -e
+set -u
+set -o pipefail
 
-arch=$(dpkg --print-architecture)
+set -x
+
+arch="$(dpkg --print-architecture)"
 user=ubuntu
-tap_dir=/home/$user/tap-setup-scripts
-uname=$(uname -m)
-set -a
+tap_dir="/home/${user}/tap-setup-scripts"
 
 echo "Installing python dependencies for $user..."
 su - $user -c "mkdir -p /home/$user/.local/bin; source /home/$user/.profile; python3 -m pip install --upgrade pip setuptools wheel yq"
@@ -81,7 +83,7 @@ install -m 0750 <( curl -fsSL "$dockerCredHelperURI" ) /usr/local/bin/docker-cre
 cat <<EOF > /root/.docker/config.json
 {
   "credHelpers": {
-    "${AWSAccountId}.dkr.ecr.${AWS_REGION}.amazonaws.com": "ecr-login",
+    "${AWSAccountID}.dkr.ecr.${AWS_REGION}.amazonaws.com": "ecr-login",
     "public.ecr.aws": "ecr-login"
   }
 }

--- a/tap-setup-scripts/src/cloud-init.sh
+++ b/tap-setup-scripts/src/cloud-init.sh
@@ -53,6 +53,29 @@ cat <<EOF >> /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json
 }
 EOF
 
+installOm() (
+  local dest="${1}"
+  local version="${2:-7.9.0}"
+  local arch="${3:-amd64}"
+
+  downloadDir="$( mktemp --directory --suffix=-om-installation )"
+  trap 'rm -rf -- "$downloadDir"' EXIT
+
+  echo "Installing om CLI ($version) ..."
+
+  cd "$downloadDir"
+
+  local baseName="om-linux-${arch}-${version}"
+
+  curl -fsSL --remote-name-all \
+    "https://github.com/pivotal-cf/om/releases/download/${version}/${baseName}" \
+    "https://github.com/pivotal-cf/om/releases/download/${version}/checksums.txt"
+
+  sha256sum --check --status --strict <( grep '\s'"$baseName"'$' checksums.txt )
+
+  install -m 0755 "$baseName" "$dest"
+)
+
 
 pushd /tmp
 aws s3 cp --no-progress "s3://amazoncloudwatch-agent-${AWS_REGION}/ubuntu/${arch}/latest/amazon-cloudwatch-agent.deb" ./amazon-cloudwatch-agent.deb
@@ -166,9 +189,13 @@ ${SampleAppConfig}
 EOF
 popd
 chown -R $user:$user "$tap_dir"
+
 echo "Installing pivnet CLI..."
 wget -O "$tap_dir/downloads/pivnet" "https://github.com/pivotal-cf/pivnet-cli/releases/download/v${PivNetVersion}/pivnet-linux-$(dpkg --print-architecture)-${PivNetVersion}"
 install -o $user -g $user -m 0755 "$tap_dir/downloads/pivnet" /usr/local/bin/pivnet
+
+installOm /usr/local/bin/om '7.9.0' 'amd64'
+
 echo "Installing Tanzu CLI and Staging Tanzu-cluster-essentials..."
 su - $user -c "$tap_dir/src/install-tools.sh"
 echo TanzuNetRelocateImages ${TanzuNetRelocateImages}

--- a/tap-setup-scripts/src/cloud-init.sh
+++ b/tap-setup-scripts/src/cloud-init.sh
@@ -190,11 +190,7 @@ EOF
 popd
 chown -R $user:$user "$tap_dir"
 
-echo "Installing pivnet CLI..."
-wget -O "$tap_dir/downloads/pivnet" "https://github.com/pivotal-cf/pivnet-cli/releases/download/v${PivNetVersion}/pivnet-linux-$(dpkg --print-architecture)-${PivNetVersion}"
-install -o $user -g $user -m 0755 "$tap_dir/downloads/pivnet" /usr/local/bin/pivnet
-
-installOm /usr/local/bin/om '7.9.0' 'amd64'
+installOm /usr/local/bin/om "${OmCLIVersion:-7.9.0}"
 
 echo "Installing Tanzu CLI and Staging Tanzu-cluster-essentials..."
 su - $user -c "$tap_dir/src/install-tools.sh"

--- a/tap-setup-scripts/src/functions.sh
+++ b/tap-setup-scripts/src/functions.sh
@@ -118,7 +118,7 @@ function installTanzuCLI {
     tanzunet::getFile \
       'tanzu-cluster-essentials' "${ESSENTIALS_VERSION}" "tanzu-cluster-essentials-linux-${arch}-*.tgz" \
       "$file" \
-      <<< "$PIVNET_TOKEN" \
+      <<< "$TANZUNET_REFRESH_TOKEN" \
     || {
       rc=$?
       echo >&2 'Could not download cluster essentials'
@@ -145,7 +145,7 @@ function installTanzuCLI {
     tanzunet::getFile \
       'tanzu-application-platform' "${TAP_VERSION}" "tanzu-framework-linux-${arch}-*" \
       "$file" \
-      <<< "$PIVNET_TOKEN" \
+      <<< "$TANZUNET_REFRESH_TOKEN" \
     || {
       rc=$?
       echo >&2 'Could not download the tanzu CLI / tanzu framework'
@@ -207,7 +207,7 @@ function readUserInputs {
   TANZUNET_REGISTRY_SECRETS_MANAGER_ARN=$(yq -r .tanzunet.secrets.credentials_arn $INPUTS/user-input-values.yaml)
   TANZUNET_REGISTRY_USERNAME=$(aws secretsmanager get-secret-value --secret-id "$TANZUNET_REGISTRY_SECRETS_MANAGER_ARN" --query "SecretString" --output text | jq -r .username)
   TANZUNET_REGISTRY_PASSWORD=$(aws secretsmanager get-secret-value --secret-id "$TANZUNET_REGISTRY_SECRETS_MANAGER_ARN" --query "SecretString" --output text | jq -r .password)
-  PIVNET_TOKEN=$(aws secretsmanager get-secret-value --secret-id "$TANZUNET_REGISTRY_SECRETS_MANAGER_ARN" --query "SecretString" --output text | jq -r .token)
+  TANZUNET_REFRESH_TOKEN=$(aws secretsmanager get-secret-value --secret-id "$TANZUNET_REGISTRY_SECRETS_MANAGER_ARN" --query "SecretString" --output text | jq -r .token)
 
   TANZUNET_REGISTRY_SERVER=$(yq -r .tanzunet.server $INPUTS/user-input-values.yaml)
   TANZUNET_RELOCATE_IMAGES=$(yq -r .tanzunet.relocate_images $INPUTS/user-input-values.yaml)

--- a/tap-setup-scripts/src/functions.sh
+++ b/tap-setup-scripts/src/functions.sh
@@ -58,67 +58,110 @@ function waitForRemoval {
   done
 }
 
+# tanzunet::getFile downloads a product file from tanzunet, given the product
+# slug, the product release version & the product filename glob; it will placce
+# the artefact to the provided file path.
+# Special care is taken in handling the tanzunet token:
+#   The token is expected to be provided on StdIn and it is only used in a
+#   subshell where `xtrace` & `verbose` is explicitly disabled. This is done,
+#   so that we don't leak the token in some debug output, logs, ... even if the
+#   caller would run with `xtrace` or `verbose` enabled.
+tanzunet::getFile() (
+  local -
+  set -e
+  set -u
+  set -o pipefail
+
+  local slug="$1"
+  local version="$2"
+  local fileGlob="$3"
+  local dest="$4"
+
+  downloadDir="$( mktemp --directory --suffix=-tanzunet-download )"
+  trap 'rm -rf -- "$downloadDir"' EXIT
+
+  cd "$downloadDir"
+
+  (
+    set +xv # disable `verbose` & `xtrace` so we don't leak the token
+    om download-product \
+      --pivnet-api-token="$(</dev/stdin)" \
+      --pivnet-product-slug="${slug}" \
+      --product-version="${version}" \
+      --file-glob="${fileGlob}" \
+      --output-directory='.'
+  )
+
+  local filePath
+
+  filePath="$( jq -er '.product_path' ./download-file.json )"
+
+  echo >&2 "moving '$(basename "$filePath")' to '$dest'"
+  mv "$filePath" "$dest"
+)
+
 function installTanzuCLI {
   requireValue ESSENTIALS_VERSION TAP_VERSION
 
   banner "Downloading kapp, secretgen configuration bundle & tanzu cli"
 
-  mkdir -p $DOWNLOADS
+  mkdir -p "$DOWNLOADS"
+
+  local file arch rc
+
+  arch="$(dpkg --print-architecture)"
 
   if [[ ! -f $DOWNLOADS/tanzu-cluster-essentials/install.sh ]]
   then
-    pivnet login --api-token="$PIVNET_TOKEN"
+    file="${DOWNLOADS}/cluster-essentials.tgz"
 
-    ESSENTIALS_FILE_NAME="tanzu-cluster-essentials-linux-$(dpkg --print-architecture)-$ESSENTIALS_VERSION.tgz"
+    tanzunet::getFile \
+      'tanzu-cluster-essentials' "${ESSENTIALS_VERSION}" "tanzu-cluster-essentials-linux-${arch}-*.tgz" \
+      "$file" \
+      <<< "$PIVNET_TOKEN" \
+    || {
+      rc=$?
+      echo >&2 'Could not download cluster essentials'
+      return $rc
+    }
 
-    ESSENTIALS_FILE_ID=$(pivnet product-files \
-      -p tanzu-cluster-essentials \
-      -r $ESSENTIALS_VERSION \
-     --format=json | jq ".[] | select(.name == \"$ESSENTIALS_FILE_NAME\").id" )
-
-    pivnet download-product-files \
-      --download-dir $DOWNLOADS \
-      --product-slug='tanzu-cluster-essentials' \
-      --release-version=$ESSENTIALS_VERSION \
-      --product-file-id=$ESSENTIALS_FILE_ID
-
-    mkdir -p $DOWNLOADS/tanzu-cluster-essentials
-    tar xvf $DOWNLOADS/$ESSENTIALS_FILE_NAME -C $DOWNLOADS/tanzu-cluster-essentials
-    sudo cp $DOWNLOADS/tanzu-cluster-essentials/imgpkg /usr/local/bin/
-    sudo cp $DOWNLOADS/tanzu-cluster-essentials/kapp /usr/local/bin/
-    sudo cp $DOWNLOADS/tanzu-cluster-essentials/kbld /usr/local/bin/
-    sudo cp $DOWNLOADS/tanzu-cluster-essentials/ytt /usr/local/bin/
+    mkdir -p "${DOWNLOADS}/tanzu-cluster-essentials"
+    tar xvf "$file" -C "${DOWNLOADS}/tanzu-cluster-essentials"
+    sudo cp "${DOWNLOADS}/tanzu-cluster-essentials/imgpkg" /usr/local/bin/
+    sudo cp "${DOWNLOADS}/tanzu-cluster-essentials/kapp"   /usr/local/bin/
+    sudo cp "${DOWNLOADS}/tanzu-cluster-essentials/kbld"   /usr/local/bin/
+    sudo cp "${DOWNLOADS}/tanzu-cluster-essentials/ytt"    /usr/local/bin/
   else
     echo "tanzu-cluster-essentials already present"
   fi
 
-  TANZU_DIR=$DOWNLOADS/tanzu
+  TANZU_DIR="${DOWNLOADS}/tanzu"
   if [[ ! -f /usr/local/bin/tanzu ]]
   then
-    mkdir -p $TANZU_DIR
+    mkdir -p "${TANZU_DIR}"
+
+    file="${DOWNLOADS}/tap-bundle.tar"
+
+    tanzunet::getFile \
+      'tanzu-application-platform' "${TAP_VERSION}" "tanzu-framework-linux-${arch}-*" \
+      "$file" \
+      <<< "$PIVNET_TOKEN" \
+    || {
+      rc=$?
+      echo >&2 'Could not download the tanzu CLI / tanzu framework'
+      return $rc
+    }
+
+    tar xvf "$file" -C "$TANZU_DIR"
     export TANZU_CLI_NO_INIT=true
-
-    pivnet login --api-token="$PIVNET_TOKEN"
-
-    TANZUCLI_FILE_ID=$(pivnet product-files \
-      -p tanzu-application-platform \
-      -r $TAP_VERSION \
-      --format=json | jq '.[] | select(.name == "tanzu-framework-bundle-linux").id' )
-
-    pivnet download-product-files \
-      --download-dir $DOWNLOADS \
-      --product-slug='tanzu-application-platform' \
-      --release-version=$TAP_VERSION \
-      --product-file-id=$TANZUCLI_FILE_ID
-
-    TANZUCLI_FILE_NAME=`ls $DOWNLOADS/tanzu-framework-linux-*`
-    # echo TANZUCLI_FILE_NAME $TANZUCLI_FILE_NAME
-    tar xvf $TANZUCLI_FILE_NAME -C $TANZU_DIR
-    export TANZU_CLI_NO_INIT=true
-    MOST_RECENT_CLI=$(find $TANZU_DIR/cli/core/ -name tanzu-core-linux_$(dpkg --print-architecture) | xargs ls -t | head -n 1)
+    MOST_RECENT_CLI="$(
+      find "${TANZU_DIR}/cli/core/" -name "tanzu-core-linux_${arch}" \
+        | xargs ls -t \
+        | head -n 1
+    )"
     echo "Installing Tanzu CLI"
-    sudo install -m 0755 $MOST_RECENT_CLI /usr/local/bin/tanzu
-    pushd $TANZU_DIR
+    sudo install -m 0755 "$MOST_RECENT_CLI" /usr/local/bin/tanzu
+    pushd "$TANZU_DIR"
     tanzu plugin install --local cli all
     popd
   else

--- a/templates/aws-tap-entrypoint-existing-vpc.template.yaml
+++ b/templates/aws-tap-entrypoint-existing-vpc.template.yaml
@@ -2374,6 +2374,19 @@ Resources:
           #! Troy: [...] you also need to set the hop limit to 2, because the default of 1 effectively disables EC2 host profile authentication [...]
           HttpPutResponseHopLimit: 2
           HttpTokens: required
+        UserData:
+          Fn::Base64: !Sub |
+            <powershell>
+            Write-Host -Object 'Setting AWS Region environment variables...'
+            [System.Environment]::SetEnvironmentVariable('AWS_REGION','${AWS::Region}',[System.EnvironmentVariableTarget]::System)
+            [System.Environment]::SetEnvironmentVariable('AWS_DEFAULT_REGION','${AWS::Region}',[System.EnvironmentVariableTarget]::System)
+            Write-Host -Object 'Installing Chocolatey...'
+            Set-ExecutionPolicy Bypass -Scope Process -Force
+            [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072
+            Invoke-Expression -Command ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
+            Write-Host -Object 'Installing Mozilla Firefox...'
+            choco install -y Firefox
+            </powershell>
   WindowsBastion:
     Type: AWS::EC2::Instance
     Properties:
@@ -2389,19 +2402,6 @@ Resources:
             Windows bastion instance for accessing the
             VMware Tanzu Application Platform cluster graphical user interface
             (GUI).
-      UserData:
-        Fn::Base64: !Sub |
-          <powershell>
-          Write-Host -Object 'Setting AWS Region environment variables...'
-          [System.Environment]::SetEnvironmentVariable('AWS_REGION','${AWS::Region}',[System.EnvironmentVariableTarget]::System)
-          [System.Environment]::SetEnvironmentVariable('AWS_DEFAULT_REGION','${AWS::Region}',[System.EnvironmentVariableTarget]::System)
-          Write-Host -Object 'Installing Chocolatey...'
-          Set-ExecutionPolicy Bypass -Scope Process -Force
-          [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072
-          Invoke-Expression -Command ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
-          Write-Host -Object 'Installing Mozilla Firefox...'
-          choco install -y Firefox
-          </powershell>
   WindowsBastionEipAssociation:
     Type: AWS::EC2::EIPAssociation
     UpdateReplacePolicy: Delete

--- a/templates/aws-tap-entrypoint-existing-vpc.template.yaml
+++ b/templates/aws-tap-entrypoint-existing-vpc.template.yaml
@@ -2018,6 +2018,22 @@ Resources:
       #! AWS::CloudFormation::Authentication:
     Properties:
       LaunchTemplateData:
+        SecurityGroupIds:
+          - !Ref LinuxBastionSecurityGroup
+        Monitoring:
+          Enabled: true
+        KeyName: !Ref KeyPairName
+        ImageId: !FindInMap [AwsAmiRegionMap, !Ref AWS::Region, US2204HVM]
+        InstanceType: m5.large
+        IamInstanceProfile:
+          Arn: !GetAtt LinuxBastionInstanceProfile.Arn
+        BlockDeviceMappings:
+          - DeviceName: /dev/sda1
+            Ebs:
+              VolumeSize: 50
+              VolumeType: gp2
+              Encrypted: true
+              DeleteOnTermination: true
         MetadataOptions:
           HttpEndpoint: enabled
           #! Troy: [...] you also need to set the hop limit to 2, because the default of 1 effectively disables EC2 host profile authentication [...]
@@ -2033,21 +2049,7 @@ Resources:
       LaunchTemplate:
         LaunchTemplateId: !Ref UbuntuBastionLaunchTemplate
         Version: !GetAtt [UbuntuBastionLaunchTemplate, DefaultVersionNumber]
-      InstanceType: m5.large
-      IamInstanceProfile: !Ref LinuxBastionInstanceProfile
-      ImageId: !FindInMap [AwsAmiRegionMap, !Ref AWS::Region, US2204HVM]
-      KeyName: !Ref KeyPairName
-      Monitoring: true
-      SecurityGroupIds:
-        - !Ref LinuxBastionSecurityGroup
       SubnetId: !Ref PublicSubnet1Id
-      BlockDeviceMappings:
-        - DeviceName: /dev/sda1
-          Ebs:
-            VolumeSize: 50
-            VolumeType: gp2
-            Encrypted: true
-            DeleteOnTermination: true
       Tags:
         - Key: Name
           Value: VMwareLinuxBastionInstance
@@ -2355,6 +2357,18 @@ Resources:
     Metadata: {}
     Properties:
       LaunchTemplateData:
+        SecurityGroupIds:
+          - !Ref WindowsBastionSecurityGroup
+        KeyName: !Ref KeyPairName
+        ImageId: !FindInMap [AwsAmiRegionMap, !Ref AWS::Region, WS2022FullBase]
+        InstanceType: t3.medium
+        IamInstanceProfile:
+          Arn: !GetAtt WindowsBastionInstanceProfile.Arn
+        BlockDeviceMappings:
+          - DeviceName: /dev/xvda
+            Ebs:
+              VolumeSize: 80
+              VolumeType: gp2
         MetadataOptions:
           HttpEndpoint: enabled
           #! Troy: [...] you also need to set the hop limit to 2, because the default of 1 effectively disables EC2 host profile authentication [...]
@@ -2366,18 +2380,7 @@ Resources:
       LaunchTemplate:
         LaunchTemplateId: !Ref WindowsBastionLaunchTemplate
         Version: !GetAtt [WindowsBastionLaunchTemplate, DefaultVersionNumber]
-      InstanceType: t3.medium
-      IamInstanceProfile: !Ref WindowsBastionInstanceProfile
-      ImageId: !FindInMap [AwsAmiRegionMap, !Ref AWS::Region, WS2022FullBase]
-      KeyName: !Ref KeyPairName
-      SecurityGroupIds:
-        - !Ref WindowsBastionSecurityGroup
       SubnetId: !Ref PublicSubnet1Id
-      BlockDeviceMappings:
-        - DeviceName: /dev/xvda
-          Ebs:
-            VolumeSize: 80
-            VolumeType: gp2
       Tags:
         - Key: Name
           Value: VMwareWindowsBastionInstance

--- a/templates/aws-tap-entrypoint-existing-vpc.template.yaml
+++ b/templates/aws-tap-entrypoint-existing-vpc.template.yaml
@@ -2011,6 +2011,18 @@ Resources:
                       - arn:${AWS::Partition}:ecr:${AWS::Region}:${AWS::AccountId}:repository/${StackId}/*
                       - StackId: !Select [2, !Split [/, !Ref AWS::StackId]]
 # roles multi cluster end
+  UbuntuBastionLaunchTemplate:
+    Type: AWS::EC2::LaunchTemplate
+    Metadata: {}
+      #! AWS::EC2::LaunchTemplate:
+      #! AWS::CloudFormation::Authentication:
+    Properties:
+      LaunchTemplateData:
+        MetadataOptions:
+          HttpEndpoint: enabled
+          #! Troy: [...] you also need to set the hop limit to 2, because the default of 1 effectively disables EC2 host profile authentication [...]
+          HttpPutResponseHopLimit: 2
+          HttpTokens: required
   UbuntuBastion:
   # TODO: Implement CloudFormation helper scripts once Ubuntu 22.04 is
   # supported.
@@ -2018,6 +2030,9 @@ Resources:
     Metadata:
       cfn-lint: { config: { ignore_checks: [I3042] } }
     Properties:
+      LaunchTemplate:
+        LaunchTemplateId: !Ref UbuntuBastionLaunchTemplate
+        Version: !GetAtt [UbuntuBastionLaunchTemplate, DefaultVersionNumber]
       InstanceType: m5.large
       IamInstanceProfile: !Ref LinuxBastionInstanceProfile
       ImageId: !FindInMap [AwsAmiRegionMap, !Ref AWS::Region, US2204HVM]
@@ -2335,9 +2350,22 @@ Resources:
         - StackId: !Select [2, !Split [/, !Ref AWS::StackId]]
       Roles:
         - !Ref WindowsBastionIamRole
+  WindowsBastionLaunchTemplate:
+    Type: AWS::EC2::LaunchTemplate
+    Metadata: {}
+    Properties:
+      LaunchTemplateData:
+        MetadataOptions:
+          HttpEndpoint: enabled
+          #! Troy: [...] you also need to set the hop limit to 2, because the default of 1 effectively disables EC2 host profile authentication [...]
+          HttpPutResponseHopLimit: 2
+          HttpTokens: required
   WindowsBastion:
     Type: AWS::EC2::Instance
     Properties:
+      LaunchTemplate:
+        LaunchTemplateId: !Ref WindowsBastionLaunchTemplate
+        Version: !GetAtt [WindowsBastionLaunchTemplate, DefaultVersionNumber]
       InstanceType: t3.medium
       IamInstanceProfile: !Ref WindowsBastionInstanceProfile
       ImageId: !FindInMap [AwsAmiRegionMap, !Ref AWS::Region, WS2022FullBase]

--- a/templates/aws-tap-entrypoint-existing-vpc.template.yaml
+++ b/templates/aws-tap-entrypoint-existing-vpc.template.yaml
@@ -618,6 +618,35 @@ Mappings:
               url: https://github.com/sample-accelerators/tanzu-java-web-app
               ref:
                 branch: main
+  #! The indirection is just there, because in Fn::FindInMap we can only
+  #! use Fn::Ref & Fn::FindInMap, but e.g. not Fn::Sub :(
+  TimeoutMap:
+    multi:
+      MapName: TimeoutsMultiCluster
+    single:
+      MapName: TimeoutsSingleCluster
+  TimeoutsSingleCluster:
+    'No': #! single cluster deployment without relocation
+      CloudInit:          "1500" # 25m
+      TAPInstall:          "600" # 10m
+      TAPWorkloadInstall:  "600" # 10m
+      TAPTests:            "300" #  5m
+    'Yes': #! single cluster deployment with relocation
+      CloudInit:          "4200" # 70m
+      TAPInstall:         "3300" # 55m
+      TAPWorkloadInstall:  "600" # 10m
+      TAPTests:            "300" #  5m
+  TimeoutsMultiCluster:
+    'No': #! multi cluster deployment without relocation
+      CloudInit:          "3300" # 55m
+      TAPInstall:         "2100" # 35m
+      TAPWorkloadInstall:  "900" # 15m
+      TAPTests:            "300" #  5m
+    'Yes': #! multi cluster deployment with relocation
+      CloudInit:          "6000" # 100m
+      TAPInstall:         "4800" #  80m
+      TAPWorkloadInstall:  "900" #  15m
+      TAPTests:            "300" #   5m
 Conditions:
   CreateMultiCluster: !Equals [!Ref TAPClusterArch, multi]
   CreateSingleCluster: !Equals [!Ref TAPClusterArch, single]
@@ -2268,7 +2297,7 @@ Resources:
     Properties:
       Count: 1
       Handle: !Ref "PhaseCloudInitHandle"
-      Timeout: "3600" # 60m
+      Timeout: !FindInMap [ !FindInMap [TimeoutMap, !Ref TAPClusterArch, MapName], !Ref TanzuNetRelocateImages, CloudInit ]
 
   # Phase for TAP install
   # from the creation of the instance to finished TAP install
@@ -2280,7 +2309,7 @@ Resources:
     Properties:
       Count: 1
       Handle: !Ref "PhaseTAPInstallHandle"
-      Timeout: "1800" # 30m
+      Timeout: !FindInMap [ !FindInMap [TimeoutMap, !Ref TAPClusterArch, MapName], !Ref TanzuNetRelocateImages, TAPInstall ]
 
   # Phase for TAP workload install
   # from finished TAP install to finished workload deployment
@@ -2292,7 +2321,7 @@ Resources:
     Properties:
       Count: 1
       Handle: !Ref "PhaseTAPWorkloadInstallHandle"
-      Timeout: "1200" # 20min
+      Timeout: !FindInMap [ !FindInMap [TimeoutMap, !Ref TAPClusterArch, MapName], !Ref TanzuNetRelocateImages, TAPWorkloadInstall ]
 
   # Phase for TAP (smoke) tests
   # from finished TAP workload deployment to finished test runs
@@ -2304,7 +2333,7 @@ Resources:
     Properties:
       Count: 1
       Handle: !Ref "PhaseTAPTestsHandle"
-      Timeout: "600" # 10m
+      Timeout: !FindInMap [ !FindInMap [TimeoutMap, !Ref TAPClusterArch, MapName], !Ref TanzuNetRelocateImages, TAPTests ]
 
   UbuntuBastionEipAssociation:
     Type: AWS::EC2::EIPAssociation

--- a/templates/aws-tap-entrypoint-existing-vpc.template.yaml
+++ b/templates/aws-tap-entrypoint-existing-vpc.template.yaml
@@ -52,7 +52,6 @@ Metadata:
       - Label:
           default: Amazon EKS configuration
         Parameters:
-          - EKSClusterName
           - NodeInstanceType
           - NodeVolumeSize
           - NumberOfNodes
@@ -86,8 +85,6 @@ Metadata:
         default: Domain name
       TAPClusterArch:
         default: EKS single or multi cluster
-      EKSClusterName:
-        default: EKS cluster name
       NodeInstanceType:
         default: Instance type
       NodeVolumeSize:
@@ -185,16 +182,6 @@ Parameters:
       are supported due to Windows instances not supporting ED25519. For more
       information, refer to Amazon EC2 key pairs and Windows instances
       (https://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/ec2-key-pairs.html).
-  EKSClusterName:
-    Type: String
-    Description: Name of the EKS cluster where TAP will be deployed.
-    MinLength: 1
-    MaxLength: 100
-    AllowedPattern: ^[0-9A-Za-z][A-Za-z0-9\-_]*
-    ConstraintDescription: >-
-      Minimum length of 1. Maximum length of 100. Must start with a letter or
-      number.
-    Default: cluster-eks-tap
   NumberOfNodes:
     Type: Number
     Description: Minimum number of nodes to create for the TAP EKS cluster.
@@ -805,7 +792,7 @@ Resources:
         NodeInstanceFamily: Standard
         NodeGroupType: Managed
         NodeGroupOS: Amazon Linux 2
-        EKSClusterName: !Ref EKSClusterName
+        EKSClusterName: !Join ['-', ['tap', !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]]]]
         ClusterAutoScaler: Enabled
         LoadBalancerController: Enabled
         PerRegionSharedResources: 'No'
@@ -844,7 +831,7 @@ Resources:
         NodeInstanceFamily: Standard
         NodeGroupType: Managed
         NodeGroupOS: Amazon Linux 2
-        EKSClusterName: !Sub ${EKSClusterName}-run
+        EKSClusterName: !Join ['-', ['tap-run', !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]]]]
         ClusterAutoScaler: Enabled
         LoadBalancerController: Enabled
         PerRegionSharedResources: 'No'
@@ -882,7 +869,7 @@ Resources:
         NodeInstanceFamily: Standard
         NodeGroupType: Managed
         NodeGroupOS: Amazon Linux 2
-        EKSClusterName: !Sub ${EKSClusterName}-view
+        EKSClusterName: !Join ['-', ['tap-view', !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]]]]
         ClusterAutoScaler: Enabled
         LoadBalancerController: Enabled
         PerRegionSharedResources: 'No'
@@ -920,7 +907,7 @@ Resources:
         NodeInstanceFamily: Standard
         NodeGroupType: Managed
         NodeGroupOS: Amazon Linux 2
-        EKSClusterName: !Sub ${EKSClusterName}-build
+        EKSClusterName: !Join ['-', ['tap-build', !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]]]]
         ClusterAutoScaler: Enabled
         LoadBalancerController: Enabled
         PerRegionSharedResources: 'No'
@@ -958,7 +945,7 @@ Resources:
         NodeInstanceFamily: Standard
         NodeGroupType: Managed
         NodeGroupOS: Amazon Linux 2
-        EKSClusterName: !Sub ${EKSClusterName}-iterate
+        EKSClusterName: !Join ['-', ['tap-iterate', !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]]]]
         ClusterAutoScaler: Enabled
         LoadBalancerController: Enabled
         PerRegionSharedResources: 'No'
@@ -1374,11 +1361,21 @@ Resources:
                   - eks:DescribeCluster
                   - eks:DescribeNodegroup
                 Resource:
-                  - !Sub arn:${AWS::Partition}:eks:${AWS::Region}:${AWS::AccountId}:cluster/${EKSClusterName}
-                  - !Sub arn:${AWS::Partition}:eks:${AWS::Region}:${AWS::AccountId}:cluster/${EKSClusterName}-run
-                  - !Sub arn:${AWS::Partition}:eks:${AWS::Region}:${AWS::AccountId}:cluster/${EKSClusterName}-build
-                  - !Sub arn:${AWS::Partition}:eks:${AWS::Region}:${AWS::AccountId}:cluster/${EKSClusterName}-iterate
-                  - !Sub arn:${AWS::Partition}:eks:${AWS::Region}:${AWS::AccountId}:cluster/${EKSClusterName}-view
+                  - !Sub
+                      - arn:${AWS::Partition}:eks:${AWS::Region}:${AWS::AccountId}:cluster/${EKSClusterNameSingle}
+                      - EKSClusterNameSingle: !Join ['-', ['tap', !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]]]]
+                  - !Sub
+                      - arn:${AWS::Partition}:eks:${AWS::Region}:${AWS::AccountId}:cluster/${EKSClusterNameRun}
+                      - EKSClusterNameRun: !Join ['-', ['tap-run', !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]]]]
+                  - !Sub
+                      - arn:${AWS::Partition}:eks:${AWS::Region}:${AWS::AccountId}:cluster/${EKSClusterNameBuild}
+                      - EKSClusterNameBuild: !Join ['-', ['tap-build', !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]]]]
+                  - !Sub
+                      - arn:${AWS::Partition}:eks:${AWS::Region}:${AWS::AccountId}:cluster/${EKSClusterNameIterate}
+                      - EKSClusterNameIterate: !Join ['-', ['tap-iterate', !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]]]]
+                  - !Sub
+                      - arn:${AWS::Partition}:eks:${AWS::Region}:${AWS::AccountId}:cluster/${EKSClusterNameView}
+                      - EKSClusterNameView: !Join ['-', ['tap-view', !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]]]]
               - Sid: DescribeEksAddons
                 Effect: Allow
                 Action:
@@ -2266,7 +2263,7 @@ Resources:
               IterateClusterWorkloadArn: !If [CreateMultiCluster, !GetAtt ITERATEWorkloadIamRole.Arn, ""]
               RunClusterName: !If [CreateMultiCluster, !GetAtt RUNEKSQSStack.Outputs.EKSClusterName, ""]
               ViewClusterName: !If [CreateMultiCluster, !GetAtt VIEWEKSQSStack.Outputs.EKSClusterName, ""]
-
+              EKSClusterName: !If [CreateSingleCluster, !GetAtt EKSQSStack.Outputs.EKSClusterName, ""]
               CloudInitHandle:          !Ref PhaseCloudInitHandle
               TAPInstallHandle:         !Ref PhaseTAPInstallHandle
               TAPWorkloadInstallHandle: !Ref PhaseTAPWorkloadInstallHandle

--- a/templates/aws-tap-entrypoint-existing-vpc.template.yaml
+++ b/templates/aws-tap-entrypoint-existing-vpc.template.yaml
@@ -2013,9 +2013,6 @@ Resources:
 # roles multi cluster end
   UbuntuBastionLaunchTemplate:
     Type: AWS::EC2::LaunchTemplate
-    Metadata: {}
-      #! AWS::EC2::LaunchTemplate:
-      #! AWS::CloudFormation::Authentication:
     Properties:
       LaunchTemplateData:
         SecurityGroupIds:
@@ -2039,6 +2036,184 @@ Resources:
           #! Troy: [...] you also need to set the hop limit to 2, because the default of 1 effectively disables EC2 host profile authentication [...]
           HttpPutResponseHopLimit: 2
           HttpTokens: required
+        UserData:
+          Fn::Base64: !Sub
+            - |
+              #!/bin/bash
+              set -e
+              set -u
+              set -o pipefail
+
+              set -x
+
+              cat <<EOF >> /etc/environment
+              AWS_REGION=${AWS::Region}
+              AWS_DEFAULT_REGION=${AWS::Region}
+              EOF
+              . /etc/environment
+              export AWS_REGION AWS_DEFAULT_REGION
+
+              set +x
+                # TODO: we should ensure to
+                #       - only export actually used vars
+                #       - never print/log those, or at least sensitive ones
+                #       - use consistent/proper/clear var names
+                #       - handle multiline/quoted/... vars correctly
+                export AWSAccountID='${AWS::AccountId}'
+                export AwsKubectlVersion='${AwsKubectlVersion}'
+                export BuildClusterBuildServiceArn='${BuildClusterBuildServiceArn}'
+                export BuildClusterName='${BuildClusterName}'
+                export BuildClusterWorkloadArn='${BuildClusterWorkloadArn}'
+                export ClusterArch='${ClusterArch}'
+                export ClusterEssentialsBundleFileHash='${ClusterEssentialsBundleFileHash}'
+                export ClusterEssentialsBundleRepo='${ClusterEssentialsBundleRepo}'
+                export ClusterEssentialsBundleVersion='${ClusterEssentialsBundleVersion}'
+                export DockerCredPassVersion='${DockerCredPassVersion}'
+                export EKSClusterName='${EKSClusterName}'
+                export IterateClusterBuildServiceArn='${IterateClusterBuildServiceArn}'
+                export IterateClusterName='${IterateClusterName}'
+                export IterateClusterWorkloadArn='${IterateClusterWorkloadArn}'
+                export PivNetVersion='${PivNetVersion}'
+                export PrivateHostedZone='${PrivateHostedZone}'
+                export QSS3BucketPath='${QSS3BucketPath}'
+                export RunClusterName='${RunClusterName}'
+                export SampleAppConfig='${SampleAppConfig}'
+                export SampleAppNamespace='${SampleAppNamespace}'
+                export SampleAppName='${SampleAppName}'
+                export TAPBuildServiceRepo_RepositoryUri='${TAPBuildServiceRepo.RepositoryUri}'
+                export TAPClusterEssentialsBundleRepo_RepositoryUri='${TAPClusterEssentialsBundleRepo.RepositoryUri}'
+                export TAPDomainName='${TAPDomainName}'
+                export TAPLogGroup='${TAPLogGroup}'
+                export TAPPackagesRepo_RepositoryUri='${TAPPackagesRepo.RepositoryUri}'
+                export TAPRepo='${TAPRepo}'
+                export TAPVersion='${TAPVersion}'
+                export TAPWorkloadRepo_RepositoryUri='${TAPWorkloadRepo.RepositoryUri}'
+                export TanzuNetRegistryServer='${TanzuNetRegistryServer}'
+                export TanzuNetRelocateImages='${TanzuNetRelocateImages}'
+                export TanzuNetSecretCredentials='${TanzuNetSecretCredentials}'
+                export ViewClusterName='${ViewClusterName}'
+
+                # WaitConditionHanldes
+                export CloudInitHandle='${CloudInitHandle}'
+                export TAPInstallHandle='${TAPInstallHandle}'
+                export TAPWorkloadInstallHandle='${TAPWorkloadInstallHandle}'
+                export TAPTestsHandle='${TAPTestsHandle}'
+              set -x
+
+              arch=$(dpkg --print-architecture)
+
+              echo "Removing built-in Docker..."
+              apt-get -y remove containerd runc
+
+              echo "Adding Docker CE repo..."
+              mkdir -p /usr/local/share/keyrings/
+              curl -fsSL https://download.docker.com/linux/ubuntu/gpg |
+                gpg --dearmor -o /usr/local/share/keyrings/docker-archive-keyring.gpg --yes
+              printf "deb [arch=$arch signed-by=/usr/local/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" |
+                tee /etc/apt/sources.list.d/docker.list
+
+              echo "Updating & upgrading..."
+              apt-get -y update
+              apt-get -y upgrade
+
+              echo "Installing system dependencies..."
+              apt-get -y install \
+                amazon-ecr-credential-helper \
+                ca-certificates \
+                containerd.io \
+                curl \
+                docker-ce \
+                docker-ce-cli \
+                docker-compose-plugin \
+                git \
+                gnupg \
+                gnupg2 \
+                jq \
+                lsb-release \
+                openssl \
+                pass \
+                perl \
+                python3-pip \
+                python3-setuptools \
+                sed \
+                sudo \
+                traceroute \
+                unzip \
+                uuid-runtime \
+                vim \
+                wget
+
+              # TODO: use mktemp and a trap to clean up (or use an AMI with AWS CLI preinstalled)
+              # Note: the Ubuntu AMI seems to come with `wget` and `curl` already installed
+              echo "Installing aws cli..."
+              pushd /tmp
+              wget -O "./awscliv2.zip" "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip"
+              unzip ./awscliv2.zip
+              ./aws/install
+              popd
+
+              echo "Installing aws-cfn-bootstrap tools & setting signal trap"
+              pip3 install "https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz"
+
+              # Set and export the cfn trap
+              cfnSignal() {
+                local -
+                set +x
+
+                local rc="${!1:-42}"
+                local handleURL="${!2:-${CloudInitHandle}}"
+                local reason='installation succeeded'
+                local ctxLines=10
+
+                (( rc != 0 )) && {
+                  local nl=$'\n'
+                  # We don't care about the last 3 lines of the log, because
+                  # that's logging the cfnSignal itself.
+                  reason="${!nl}$( tail -n $(( ctxLines + 3 )) /var/log/cloud-init-output.log | head -n -3 )${!nl}"
+                }
+
+                cfn-signal --region "${!AWS_REGION}" --exit-code "$rc" --reason "$reason" "$handleURL" \
+                  || echo >&2 'could not run cfn-signal'
+              }
+              export -f cfnSignal
+              trap 'cfnSignal $?' ERR
+
+              cInit="${!QSS3BucketPath}/src/cloud-init.sh"
+              echo "kicking off cloud-init from '${!cInit}'"
+              bash -xe <(
+                aws s3 cp --no-progress "${!cInit}" -
+              )
+
+              cfnSignal 0
+            - AwsKubectlVersion: !FindInMap [ Versions, current, Kubectl ]
+              TAPVersion: !FindInMap [ Versions, current, TAP ]
+              ClusterEssentialsBundleRepo: tanzu-cluster-essentials/cluster-essentials-bundle
+              ClusterEssentialsBundleFileHash: !FindInMap [ Versions, current, ClusterEssentialsHash ]
+              ClusterEssentialsBundleVersion: !FindInMap [ Versions, current, ClusterEssentialsVersion ]
+              DockerCredPassVersion: !FindInMap [ Versions, current, DockerCredPass ]
+              PivNetVersion: !FindInMap [ Versions, current, PivNet ]
+              SampleAppConfig: !FindInMap [Apps, Sample, Config]
+              SampleAppNamespace: !FindInMap [Apps, Sample, Namespace]
+              SampleAppName: !FindInMap [Apps, Sample, Name]
+              QSS3BucketPath: !Sub
+                - s3://${S3Bucket}/${QSS3KeyPrefix}tap-setup-scripts
+                - S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
+              TanzuNetRegistryServer: !FindInMap [TanzuNetRegistryServer, Server, Name]
+              TAPRepo: tanzu-application-platform/tap-packages
+              ClusterArch: !Ref TAPClusterArch
+              BuildClusterName: !If [CreateMultiCluster, !GetAtt BUILDEKSQSStack.Outputs.EKSClusterName, !GetAtt EKSQSStack.Outputs.EKSClusterName]
+              BuildClusterBuildServiceArn: !If [CreateMultiCluster, !GetAtt BUILDBuildServiceIamRole.Arn, !GetAtt TAPBuildServiceIamRole.Arn]
+              BuildClusterWorkloadArn: !If [CreateMultiCluster, !GetAtt BUILDWorkloadIamRole.Arn, !GetAtt TAPWorkloadIamRole.Arn]
+              IterateClusterName: !If [CreateMultiCluster, !GetAtt ITERATEEKSQSStack.Outputs.EKSClusterName, ""]
+              IterateClusterBuildServiceArn: !If [CreateMultiCluster, !GetAtt ITERATEBuildServiceIamRole.Arn, ""]
+              IterateClusterWorkloadArn: !If [CreateMultiCluster, !GetAtt ITERATEWorkloadIamRole.Arn, ""]
+              RunClusterName: !If [CreateMultiCluster, !GetAtt RUNEKSQSStack.Outputs.EKSClusterName, ""]
+              ViewClusterName: !If [CreateMultiCluster, !GetAtt VIEWEKSQSStack.Outputs.EKSClusterName, ""]
+
+              CloudInitHandle:          !Ref PhaseCloudInitHandle
+              TAPInstallHandle:         !Ref PhaseTAPInstallHandle
+              TAPWorkloadInstallHandle: !Ref PhaseTAPWorkloadInstallHandle
+              TAPTestsHandle:           !Ref PhaseTAPTestsHandle
   UbuntuBastion:
   # TODO: Implement CloudFormation helper scripts once Ubuntu 22.04 is
   # supported.
@@ -2054,186 +2229,7 @@ Resources:
         - Key: Name
           Value: VMwareLinuxBastionInstance
         - Key: Description
-          Value: >-
-            VMware Tanzu Application Platform EKS cluster bootstrap instance.
-      UserData:
-        Fn::Base64: !Sub
-          - |
-            #!/bin/bash
-            set -e
-            set -u
-            set -o pipefail
-
-            set -x
-
-            cat <<EOF >> /etc/environment
-            AWS_REGION=${AWS::Region}
-            AWS_DEFAULT_REGION=${AWS::Region}
-            EOF
-            . /etc/environment
-            export AWS_REGION AWS_DEFAULT_REGION
-
-            set +x
-              # TODO: we should ensure to
-              #       - only export actually used vars
-              #       - never print/log those, or at least sensitive ones
-              #       - use consistent/proper/clear var names
-              #       - handle multiline/quoted/... vars correctly
-              export AWSAccountID='${AWS::AccountId}'
-              export AwsKubectlVersion='${AwsKubectlVersion}'
-              export BuildClusterBuildServiceArn='${BuildClusterBuildServiceArn}'
-              export BuildClusterName='${BuildClusterName}'
-              export BuildClusterWorkloadArn='${BuildClusterWorkloadArn}'
-              export ClusterArch='${ClusterArch}'
-              export ClusterEssentialsBundleFileHash='${ClusterEssentialsBundleFileHash}'
-              export ClusterEssentialsBundleRepo='${ClusterEssentialsBundleRepo}'
-              export ClusterEssentialsBundleVersion='${ClusterEssentialsBundleVersion}'
-              export DockerCredPassVersion='${DockerCredPassVersion}'
-              export EKSClusterName='${EKSClusterName}'
-              export IterateClusterBuildServiceArn='${IterateClusterBuildServiceArn}'
-              export IterateClusterName='${IterateClusterName}'
-              export IterateClusterWorkloadArn='${IterateClusterWorkloadArn}'
-              export PivNetVersion='${PivNetVersion}'
-              export PrivateHostedZone='${PrivateHostedZone}'
-              export QSS3BucketPath='${QSS3BucketPath}'
-              export RunClusterName='${RunClusterName}'
-              export SampleAppConfig='${SampleAppConfig}'
-              export SampleAppNamespace='${SampleAppNamespace}'
-              export SampleAppName='${SampleAppName}'
-              export TAPBuildServiceRepo_RepositoryUri='${TAPBuildServiceRepo.RepositoryUri}'
-              export TAPClusterEssentialsBundleRepo_RepositoryUri='${TAPClusterEssentialsBundleRepo.RepositoryUri}'
-              export TAPDomainName='${TAPDomainName}'
-              export TAPLogGroup='${TAPLogGroup}'
-              export TAPPackagesRepo_RepositoryUri='${TAPPackagesRepo.RepositoryUri}'
-              export TAPRepo='${TAPRepo}'
-              export TAPVersion='${TAPVersion}'
-              export TAPWorkloadRepo_RepositoryUri='${TAPWorkloadRepo.RepositoryUri}'
-              export TanzuNetRegistryServer='${TanzuNetRegistryServer}'
-              export TanzuNetRelocateImages='${TanzuNetRelocateImages}'
-              export TanzuNetSecretCredentials='${TanzuNetSecretCredentials}'
-              export ViewClusterName='${ViewClusterName}'
-
-              # WaitConditionHanldes
-              export CloudInitHandle='${CloudInitHandle}'
-              export TAPInstallHandle='${TAPInstallHandle}'
-              export TAPWorkloadInstallHandle='${TAPWorkloadInstallHandle}'
-              export TAPTestsHandle='${TAPTestsHandle}'
-            set -x
-
-            arch=$(dpkg --print-architecture)
-
-            echo "Removing built-in Docker..."
-            apt-get -y remove containerd runc
-
-            echo "Adding Docker CE repo..."
-            mkdir -p /usr/local/share/keyrings/
-            curl -fsSL https://download.docker.com/linux/ubuntu/gpg |
-              gpg --dearmor -o /usr/local/share/keyrings/docker-archive-keyring.gpg --yes
-            printf "deb [arch=$arch signed-by=/usr/local/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" |
-              tee /etc/apt/sources.list.d/docker.list
-
-            echo "Updating & upgrading..."
-            apt-get -y update
-            apt-get -y upgrade
-
-            echo "Installing system dependencies..."
-            apt-get -y install \
-              amazon-ecr-credential-helper \
-              ca-certificates \
-              containerd.io \
-              curl \
-              docker-ce \
-              docker-ce-cli \
-              docker-compose-plugin \
-              git \
-              gnupg \
-              gnupg2 \
-              jq \
-              lsb-release \
-              openssl \
-              pass \
-              perl \
-              python3-pip \
-              python3-setuptools \
-              sed \
-              sudo \
-              traceroute \
-              unzip \
-              uuid-runtime \
-              vim \
-              wget
-
-            # TODO: use mktemp and a trap to clean up (or use an AMI with AWS CLI preinstalled)
-            # Note: the Ubuntu AMI seems to come with `wget` and `curl` already installed
-            echo "Installing aws cli..."
-            pushd /tmp
-            wget -O "./awscliv2.zip" "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip"
-            unzip ./awscliv2.zip
-            ./aws/install
-            popd
-
-            echo "Installing aws-cfn-bootstrap tools & setting signal trap"
-            pip3 install "https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz"
-
-            # Set and export the cfn trap
-            cfnSignal() {
-              local -
-              set +x
-
-              local rc="${!1:-42}"
-              local handleURL="${!2:-${CloudInitHandle}}"
-              local reason='installation succeeded'
-              local ctxLines=10
-
-              (( rc != 0 )) && {
-                local nl=$'\n'
-                # We don't care about the last 3 lines of the log, because
-                # that's logging the cfnSignal itself.
-                reason="${!nl}$( tail -n $(( ctxLines + 3 )) /var/log/cloud-init-output.log | head -n -3 )${!nl}"
-              }
-
-              cfn-signal --region "${!AWS_REGION}" --exit-code "$rc" --reason "$reason" "$handleURL" \
-                || echo >&2 'could not run cfn-signal'
-            }
-            export -f cfnSignal
-            trap 'cfnSignal $?' ERR
-
-            cInit="${!QSS3BucketPath}/src/cloud-init.sh"
-            echo "kicking off cloud-init from '${!cInit}'"
-            bash -xe <(
-              aws s3 cp --no-progress "${!cInit}" -
-            )
-
-            cfnSignal 0
-          - AwsKubectlVersion: !FindInMap [ Versions, current, Kubectl ]
-            TAPVersion: !FindInMap [ Versions, current, TAP ]
-            ClusterEssentialsBundleRepo: tanzu-cluster-essentials/cluster-essentials-bundle
-            ClusterEssentialsBundleFileHash: !FindInMap [ Versions, current, ClusterEssentialsHash ]
-            ClusterEssentialsBundleVersion: !FindInMap [ Versions, current, ClusterEssentialsVersion ]
-            DockerCredPassVersion: !FindInMap [ Versions, current, DockerCredPass ]
-            PivNetVersion: !FindInMap [ Versions, current, PivNet ]
-            SampleAppConfig: !FindInMap [Apps, Sample, Config]
-            SampleAppNamespace: !FindInMap [Apps, Sample, Namespace]
-            SampleAppName: !FindInMap [Apps, Sample, Name]
-            QSS3BucketPath: !Sub
-              - s3://${S3Bucket}/${QSS3KeyPrefix}tap-setup-scripts
-              - S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
-            TanzuNetRegistryServer: !FindInMap [TanzuNetRegistryServer, Server, Name]
-            TAPRepo: tanzu-application-platform/tap-packages
-            ClusterArch: !Ref TAPClusterArch
-            BuildClusterName: !If [CreateMultiCluster, !GetAtt BUILDEKSQSStack.Outputs.EKSClusterName, !GetAtt EKSQSStack.Outputs.EKSClusterName]
-            BuildClusterBuildServiceArn: !If [CreateMultiCluster, !GetAtt BUILDBuildServiceIamRole.Arn, !GetAtt TAPBuildServiceIamRole.Arn]
-            BuildClusterWorkloadArn: !If [CreateMultiCluster, !GetAtt BUILDWorkloadIamRole.Arn, !GetAtt TAPWorkloadIamRole.Arn]
-            IterateClusterName: !If [CreateMultiCluster, !GetAtt ITERATEEKSQSStack.Outputs.EKSClusterName, ""]
-            IterateClusterBuildServiceArn: !If [CreateMultiCluster, !GetAtt ITERATEBuildServiceIamRole.Arn, ""]
-            IterateClusterWorkloadArn: !If [CreateMultiCluster, !GetAtt ITERATEWorkloadIamRole.Arn, ""]
-            RunClusterName: !If [CreateMultiCluster, !GetAtt RUNEKSQSStack.Outputs.EKSClusterName, ""]
-            ViewClusterName: !If [CreateMultiCluster, !GetAtt VIEWEKSQSStack.Outputs.EKSClusterName, ""]
-
-            CloudInitHandle:          !Ref PhaseCloudInitHandle
-            TAPInstallHandle:         !Ref PhaseTAPInstallHandle
-            TAPWorkloadInstallHandle: !Ref PhaseTAPWorkloadInstallHandle
-            TAPTestsHandle:           !Ref PhaseTAPTestsHandle
+          Value: VMware Tanzu Application Platform EKS cluster bootstrap instance.
 
   # Phase for the whole cloud-init process
   # from the creation of the instance to finished cloud-init run

--- a/templates/aws-tap-entrypoint-existing-vpc.template.yaml
+++ b/templates/aws-tap-entrypoint-existing-vpc.template.yaml
@@ -831,7 +831,7 @@ Resources:
         NodeInstanceFamily: Standard
         NodeGroupType: Managed
         NodeGroupOS: Amazon Linux 2
-        EKSClusterName: !Join ['-', ['tap-run', !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]]]]
+        EKSClusterName: !Join ['-', ['tap', !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]], 'run']]
         ClusterAutoScaler: Enabled
         LoadBalancerController: Enabled
         PerRegionSharedResources: 'No'
@@ -869,7 +869,7 @@ Resources:
         NodeInstanceFamily: Standard
         NodeGroupType: Managed
         NodeGroupOS: Amazon Linux 2
-        EKSClusterName: !Join ['-', ['tap-view', !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]]]]
+        EKSClusterName: !Join ['-', ['tap', !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]], 'view']]
         ClusterAutoScaler: Enabled
         LoadBalancerController: Enabled
         PerRegionSharedResources: 'No'
@@ -907,7 +907,7 @@ Resources:
         NodeInstanceFamily: Standard
         NodeGroupType: Managed
         NodeGroupOS: Amazon Linux 2
-        EKSClusterName: !Join ['-', ['tap-build', !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]]]]
+        EKSClusterName: !Join ['-', ['tap', !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]], 'build']]
         ClusterAutoScaler: Enabled
         LoadBalancerController: Enabled
         PerRegionSharedResources: 'No'
@@ -945,7 +945,7 @@ Resources:
         NodeInstanceFamily: Standard
         NodeGroupType: Managed
         NodeGroupOS: Amazon Linux 2
-        EKSClusterName: !Join ['-', ['tap-iterate', !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]]]]
+        EKSClusterName: !Join ['-', ['tap', !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]], 'iterate']]
         ClusterAutoScaler: Enabled
         LoadBalancerController: Enabled
         PerRegionSharedResources: 'No'
@@ -1362,20 +1362,20 @@ Resources:
                   - eks:DescribeNodegroup
                 Resource:
                   - !Sub
-                      - arn:${AWS::Partition}:eks:${AWS::Region}:${AWS::AccountId}:cluster/${EKSClusterNameSingle}
-                      - EKSClusterNameSingle: !Join ['-', ['tap', !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]]]]
+                      - arn:${AWS::Partition}:eks:${AWS::Region}:${AWS::AccountId}:cluster/${clusterName}
+                      - clusterName: !Join ['-', ['tap', !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]]]]
                   - !Sub
-                      - arn:${AWS::Partition}:eks:${AWS::Region}:${AWS::AccountId}:cluster/${EKSClusterNameRun}
-                      - EKSClusterNameRun: !Join ['-', ['tap-run', !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]]]]
+                      - arn:${AWS::Partition}:eks:${AWS::Region}:${AWS::AccountId}:cluster/${clusterName}
+                      - clusterName: !Join ['-', ['tap', !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]], 'run']]
                   - !Sub
-                      - arn:${AWS::Partition}:eks:${AWS::Region}:${AWS::AccountId}:cluster/${EKSClusterNameBuild}
-                      - EKSClusterNameBuild: !Join ['-', ['tap-build', !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]]]]
+                      - arn:${AWS::Partition}:eks:${AWS::Region}:${AWS::AccountId}:cluster/${clusterName}
+                      - clusterName: !Join ['-', ['tap', !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]], 'build']]
                   - !Sub
-                      - arn:${AWS::Partition}:eks:${AWS::Region}:${AWS::AccountId}:cluster/${EKSClusterNameIterate}
-                      - EKSClusterNameIterate: !Join ['-', ['tap-iterate', !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]]]]
+                      - arn:${AWS::Partition}:eks:${AWS::Region}:${AWS::AccountId}:cluster/${clusterName}
+                      - clusterName: !Join ['-', ['tap', !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]], 'iterate']]
                   - !Sub
-                      - arn:${AWS::Partition}:eks:${AWS::Region}:${AWS::AccountId}:cluster/${EKSClusterNameView}
-                      - EKSClusterNameView: !Join ['-', ['tap-view', !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]]]]
+                      - arn:${AWS::Partition}:eks:${AWS::Region}:${AWS::AccountId}:cluster/${clusterName}
+                      - clusterName: !Join ['-', ['tap', !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]], 'view']]
               - Sid: DescribeEksAddons
                 Effect: Allow
                 Action:
@@ -2263,7 +2263,13 @@ Resources:
               IterateClusterWorkloadArn: !If [CreateMultiCluster, !GetAtt ITERATEWorkloadIamRole.Arn, ""]
               RunClusterName: !If [CreateMultiCluster, !GetAtt RUNEKSQSStack.Outputs.EKSClusterName, ""]
               ViewClusterName: !If [CreateMultiCluster, !GetAtt VIEWEKSQSStack.Outputs.EKSClusterName, ""]
-              EKSClusterName: !If [CreateSingleCluster, !GetAtt EKSQSStack.Outputs.EKSClusterName, ""]
+
+              #! TODO:
+              #!   We need this regardless of deployment arch, so we can't use
+              #!   the EKS stack's output here. We should change the cloud-init
+              #!   to not rely on that for the multi-cluster case.
+              EKSClusterName: !Join ['-', ['tap', !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]]]]
+
               CloudInitHandle:          !Ref PhaseCloudInitHandle
               TAPInstallHandle:         !Ref PhaseTAPInstallHandle
               TAPWorkloadInstallHandle: !Ref PhaseTAPWorkloadInstallHandle

--- a/templates/aws-tap-entrypoint-existing-vpc.template.yaml
+++ b/templates/aws-tap-entrypoint-existing-vpc.template.yaml
@@ -731,7 +731,6 @@ Resources:
         ConfigSetName: !Ref AWS::StackName
         NodeVolumeSize: !Ref NodeVolumeSize
         KubernetesVersion: !FindInMap [ Versions, current, EKS ]
-#shared resources for multi cluster
   AutoDetectSharedResources:
     Type: AWS::CloudFormation::Stack
     Properties:

--- a/templates/aws-tap-entrypoint-existing-vpc.template.yaml
+++ b/templates/aws-tap-entrypoint-existing-vpc.template.yaml
@@ -504,11 +504,11 @@ Mappings:
       #! https://docs.aws.amazon.com/eks/latest/userguide/install-kubectl.html
       Kubectl: 1.24.9/2023-01-11
       ClusterEssentialsVersion: 1.4.1
-      #! Note: this is not the hash of the pivnet artifact, but rather the image hash for the bundle image;
+      #! Note: this is not the hash of the tanzunet artifact, but rather the image hash for the bundle image;
       #! You can get it e.g. by
       #!   docker pull registry.tanzu.vmware.com/tanzu-cluster-essentials/cluster-essentials-bundle:1.4.1
       ClusterEssentialsHash: sha256:2354688e46d4bb4060f74fca069513c9b42ffa17a0a6d5b0dbb81ed52242ea44
-      PivNet: 3.0.1
+      OmCLI: 7.9.0
       DockerCredPass:  0.7.0
   AwsAmiRegionMap:
     af-south-1:
@@ -2129,7 +2129,7 @@ Resources:
                 export IterateClusterBuildServiceArn='${IterateClusterBuildServiceArn}'
                 export IterateClusterName='${IterateClusterName}'
                 export IterateClusterWorkloadArn='${IterateClusterWorkloadArn}'
-                export PivNetVersion='${PivNetVersion}'
+                export OmCLIVersion='${OmCLIVersion}'
                 export PrivateHostedZone='${PrivateHostedZone}'
                 export QSS3BucketPath='${QSS3BucketPath}'
                 export RunClusterName='${RunClusterName}'
@@ -2248,7 +2248,7 @@ Resources:
               ClusterEssentialsBundleFileHash: !FindInMap [ Versions, current, ClusterEssentialsHash ]
               ClusterEssentialsBundleVersion: !FindInMap [ Versions, current, ClusterEssentialsVersion ]
               DockerCredPassVersion: !FindInMap [ Versions, current, DockerCredPass ]
-              PivNetVersion: !FindInMap [ Versions, current, PivNet ]
+              OmCLIVersion: !FindInMap [ Versions, current, OmCLI ]
               SampleAppConfig: !FindInMap [Apps, Sample, Config]
               SampleAppNamespace: !FindInMap [Apps, Sample, Namespace]
               SampleAppName: !FindInMap [Apps, Sample, Name]

--- a/templates/aws-tap-entrypoint-existing-vpc.template.yaml
+++ b/templates/aws-tap-entrypoint-existing-vpc.template.yaml
@@ -2114,6 +2114,7 @@ Resources:
                 export TAPRepo='${TAPRepo}'
                 export TAPVersion='${TAPVersion}'
                 export TAPWorkloadRepo_RepositoryUri='${TAPWorkloadRepo.RepositoryUri}'
+                export TAPWorkloadBundleRepo_RepositoryUri='${TAPWorkloadBundleRepo.RepositoryUri}'
                 export TanzuNetRegistryServer='${TanzuNetRegistryServer}'
                 export TanzuNetRelocateImages='${TanzuNetRelocateImages}'
                 export TanzuNetSecretCredentials='${TanzuNetSecretCredentials}'

--- a/templates/aws-tap-entrypoint-existing-vpc.template.yaml
+++ b/templates/aws-tap-entrypoint-existing-vpc.template.yaml
@@ -731,11 +731,24 @@ Resources:
         ConfigSetName: !Ref AWS::StackName
         NodeVolumeSize: !Ref NodeVolumeSize
         KubernetesVersion: !FindInMap [ Versions, current, EKS ]
+#shared resources for multi cluster
+  AutoDetectSharedResources:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      TemplateURL: !Sub
+        - https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}submodules/quickstart-amazon-eks/templates/workloads/amazon-eks-prerequisites.template.yaml
+        - S3Region: !If [UsingDefaultBucket, !Ref AWS::Region, !Ref QSS3BucketRegion]
+          S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
+      Parameters:
+        QSS3BucketName: !Ref QSS3BucketName
+        QSS3BucketRegion: !Ref QSS3BucketRegion
+        QSS3KeyPrefix: !Sub ${QSS3KeyPrefix}submodules/quickstart-amazon-eks/
   EKSQSStack:
     Type: AWS::CloudFormation::Stack
     Condition: CreateSingleCluster
     DependsOn:
       - EKSAdvancedConfigStack
+      - AutoDetectSharedResources
     Properties:
       TemplateURL: !Sub
         - https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}submodules/quickstart-amazon-eks/templates/amazon-eks-entrypoint-existing-vpc.template.yaml
@@ -766,12 +779,15 @@ Resources:
         EKSClusterName: !Ref EKSClusterName
         ClusterAutoScaler: Enabled
         LoadBalancerController: Enabled
+        PerRegionSharedResources: 'No'
+        PerAccountSharedResources: 'No'
 #eks stacks multi cluster start
   RUNEKSQSStack:
     Type: AWS::CloudFormation::Stack
     Condition: CreateMultiCluster
     DependsOn:
       - EKSAdvancedConfigStack
+      - AutoDetectSharedResources
     Properties:
       TemplateURL: !Sub
         - https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}submodules/quickstart-amazon-eks/templates/amazon-eks-entrypoint-existing-vpc.template.yaml
@@ -802,11 +818,14 @@ Resources:
         EKSClusterName: !Sub ${EKSClusterName}-run
         ClusterAutoScaler: Enabled
         LoadBalancerController: Enabled
+        PerRegionSharedResources: 'No'
+        PerAccountSharedResources: 'No'
   VIEWEKSQSStack:
     Type: AWS::CloudFormation::Stack
     Condition: CreateMultiCluster
     DependsOn:
       - EKSAdvancedConfigStack
+      - AutoDetectSharedResources
     Properties:
       TemplateURL: !Sub
         - https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}submodules/quickstart-amazon-eks/templates/amazon-eks-entrypoint-existing-vpc.template.yaml
@@ -837,11 +856,14 @@ Resources:
         EKSClusterName: !Sub ${EKSClusterName}-view
         ClusterAutoScaler: Enabled
         LoadBalancerController: Enabled
+        PerRegionSharedResources: 'No'
+        PerAccountSharedResources: 'No'
   BUILDEKSQSStack:
     Type: AWS::CloudFormation::Stack
     Condition: CreateMultiCluster
     DependsOn:
       - EKSAdvancedConfigStack
+      - AutoDetectSharedResources
     Properties:
       TemplateURL: !Sub
         - https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}submodules/quickstart-amazon-eks/templates/amazon-eks-entrypoint-existing-vpc.template.yaml
@@ -872,11 +894,14 @@ Resources:
         EKSClusterName: !Sub ${EKSClusterName}-build
         ClusterAutoScaler: Enabled
         LoadBalancerController: Enabled
+        PerRegionSharedResources: 'No'
+        PerAccountSharedResources: 'No'
   ITERATEEKSQSStack:
     Type: AWS::CloudFormation::Stack
     Condition: CreateMultiCluster
     DependsOn:
       - EKSAdvancedConfigStack
+      - AutoDetectSharedResources
     Properties:
       TemplateURL: !Sub
         - https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}submodules/quickstart-amazon-eks/templates/amazon-eks-entrypoint-existing-vpc.template.yaml
@@ -907,6 +932,8 @@ Resources:
         EKSClusterName: !Sub ${EKSClusterName}-iterate
         ClusterAutoScaler: Enabled
         LoadBalancerController: Enabled
+        PerRegionSharedResources: 'No'
+        PerAccountSharedResources: 'No'
 #eks stacks for multi cluster end
 #Rules for multi cluster start
   RunLinuxBastionSshToNodesEgressRule:

--- a/templates/aws-tap-entrypoint-existing-vpc.template.yaml
+++ b/templates/aws-tap-entrypoint-existing-vpc.template.yaml
@@ -137,10 +137,11 @@ Parameters:
       - 'No'
     Default: 'No'
   TAPDomainName:
-   Type: String
-   Description: >-
+    Type: String
+    Description: >-
       Private DNS domain name for accessing the TAP graphical user interface
       (GUI) and project URLs.
+    AllowedPattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$  #! from cnrs
   TAPClusterArch:
     Type: String
     Description: TAP cluster architecture.

--- a/templates/aws-tap-entrypoint-new-vpc.template.yaml
+++ b/templates/aws-tap-entrypoint-new-vpc.template.yaml
@@ -56,7 +56,6 @@ Metadata:
       - Label:
           default: Amazon EKS configuration
         Parameters:
-          - EKSClusterName
           - NodeInstanceType
           - NodeVolumeSize
           - NumberOfNodes
@@ -98,8 +97,6 @@ Metadata:
         default: Domain name
       TAPClusterArch:
         default: EKS single or multi cluster
-      EKSClusterName:
-        default: EKS cluster name
       NodeInstanceType:
         default: Instance type
       NodeVolumeSize:
@@ -234,17 +231,6 @@ Parameters:
       are supported due to Windows instances not supporting ED25519. For more
       information, refer to Amazon EC2 key pairs and Windows instances
       (https://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/ec2-key-pairs.html).
-  EKSClusterName:
-    Type: String
-    Description: >-
-      Name of the EKS cluster where TAP will be deployed.
-    MinLength: 1
-    MaxLength: 100
-    AllowedPattern: ^[0-9A-Za-z][A-Za-z0-9\-_]*
-    ConstraintDescription: >-
-      Minimum length of 1. Maximum length of 100. Must start with a letter or
-      number.
-    Default: cluster-eks-tap
   NumberOfNodes:
     Type: Number
     Description: Minimum number of nodes to create for the TAP EKS cluster.
@@ -596,7 +582,6 @@ Resources:
         MaxNumberOfNodes: !Ref MaxNumberOfNodes
         NodeInstanceType: !Ref NodeInstanceType
         NodeVolumeSize: !Ref NodeVolumeSize
-        EKSClusterName: !Ref EKSClusterName
         TAPDomainName: !Ref TAPDomainName
         TAPClusterArch: !Ref TAPClusterArch
         TanzuNetUsername: !Ref TanzuNetUsername

--- a/templates/aws-tap-entrypoint-new-vpc.template.yaml
+++ b/templates/aws-tap-entrypoint-new-vpc.template.yaml
@@ -149,10 +149,11 @@ Parameters:
       - 'No'
     Default: 'No'
   TAPDomainName:
-   Type: String
-   Description: >-
+    Type: String
+    Description: >-
       Private DNS domain name for accessing the TAP graphical user interface
       (GUI) and project URLs.
+    AllowedPattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$  #! from cnrs
   TAPClusterArch:
     Type: String
     Description: TAP cluster architecture.


### PR DESCRIPTION
*Description of changes:*

user-facing changes:
- (bugfix) Relocation of  TAP container images was broken, that is fixed now
- (feature) We removed the option to specify cluster names so that name clashes are less likely
- (feature) The bastion hosts now us Instance Metadata Service Version 2 (IMDSv2)
- (feature) We changed how we check and deploy the shared resources stacks (`eks-quickstart-RegionalSharedResources` & `eks-quickstart-AccountSharedResources`) which results in a bit faster deployments and less chance to run into race-conditions

changes interesting to Troy/AWS:
- We've added more tests, we also test relocation of images now. This might mean that `.taskcat_overrides.yml` needs slight changes in AWS' CI; re. the `TanzuNetRelocateImages`

other (internal) changes:
- The bastion hosts get deployed with a launch templates and all(?)/most configuration has been moved from the instance to the launch template
- We test relocation (for single & multi cluster) in our internal pipeline
- We now use the `om` CLI instead of the `pivnet` one, because that one is supported/patched/maintained
- The timeouts we allow for the cloud-int/setup-script has been adapted for the different deployment options (multi- vs. single cluster × relocation vs. no relocation)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
